### PR TITLE
🔒 [security] Fix command injection in cmd_stop

### DIFF
--- a/scripts/scenectl.py
+++ b/scripts/scenectl.py
@@ -318,7 +318,10 @@ def cmd_stop(args: argparse.Namespace) -> int:
     if args.scene_syncd:
         names.append("scene-syncd")
     for name in names:
-        subprocess.run(["powershell", "-NoProfile", "-Command", f"Get-Process {name} -ErrorAction SilentlyContinue | Stop-Process"], check=False)
+        subprocess.run(
+            ["powershell", "-NoProfile", "-Command", "Get-Process $args[0] -ErrorAction SilentlyContinue | Stop-Process", name],
+            check=False,
+        )
         print(f"stopped {name} if it was running")
     return 0
 


### PR DESCRIPTION
🎯 **What:** Fixed a command injection vulnerability in `scripts/scenectl.py` within the `cmd_stop` function.
⚠️ **Risk:** The previous implementation used f-string interpolation to build a PowerShell command string, allowing an attacker who can control process names to execute arbitrary PowerShell commands.
🛡️ **Solution:** Switched to using a parameterized PowerShell command by passing the process name as a separate argument to `subprocess.run` and referencing it via `$args[0]` in the command string.

---
*PR created automatically by Jules for task [6661149232558571209](https://jules.google.com/task/6661149232558571209) started by @neko-jpg*