### PR TITLE
feat: Add MCP tools and C++ stubs for animation and rigging tasks

### DIFF
--- a/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPEditorCommands.cpp
+++ b/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPEditorCommands.cpp
@@ -76,6 +76,10 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPEditorCommands::HandleCommand(const FStrin
         {TEXT("delete_instance_set"), &FEpicUnrealMCPEditorCommands::HandleDeleteInstanceSet},
         {TEXT("get_instance_set_state"), &FEpicUnrealMCPEditorCommands::HandleGetInstanceSetState},
         {TEXT("list_instance_sets"), &FEpicUnrealMCPEditorCommands::HandleListInstanceSets},
+        {TEXT("auto_skin_mesh"), &FEpicUnrealMCPEditorCommands::HandleAutoSkinMesh},
+        {TEXT("generate_control_rig"), &FEpicUnrealMCPEditorCommands::HandleGenerateControlRig},
+        {TEXT("cleanup_animation"), &FEpicUnrealMCPEditorCommands::HandleCleanupAnimation},
+        {TEXT("generate_procedural_anim"), &FEpicUnrealMCPEditorCommands::HandleGenerateProceduralAnim},
     };
 
     const Handler* H = Dispatch.Find(CommandType);
@@ -2465,4 +2469,72 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPEditorCommands::HandleListInstanceSets(con
     ResultObj->SetNumberField(TEXT("count"), SetArray.Num());
     ResultObj->SetArrayField(TEXT("sets"), SetArray);
     return ResultObj;
+}
+
+TSharedPtr<FJsonObject> FEpicUnrealMCPEditorCommands::HandleAutoSkinMesh(const TSharedPtr<FJsonObject>& Params)
+{
+    FString StaticMeshPath;
+    if (!Params->TryGetStringField(TEXT("static_mesh_path"), StaticMeshPath))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'static_mesh_path' parameter"));
+    }
+
+    UE_LOG(LogTemp, Display, TEXT("FEpicUnrealMCPEditorCommands::HandleAutoSkinMesh: Target=%s"), *StaticMeshPath);
+
+    TSharedPtr<FJsonObject> ResultData = MakeShareable(new FJsonObject);
+    ResultData->SetStringField(TEXT("message"), TEXT("Auto skinning mesh command received (Stub implementation)"));
+    ResultData->SetStringField(TEXT("static_mesh_path"), StaticMeshPath);
+
+    return FEpicUnrealMCPCommonUtils::CreateSuccessResponse(ResultData);
+}
+
+TSharedPtr<FJsonObject> FEpicUnrealMCPEditorCommands::HandleGenerateControlRig(const TSharedPtr<FJsonObject>& Params)
+{
+    FString SkeletalMeshPath;
+    if (!Params->TryGetStringField(TEXT("skeletal_mesh_path"), SkeletalMeshPath))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'skeletal_mesh_path' parameter"));
+    }
+
+    UE_LOG(LogTemp, Display, TEXT("FEpicUnrealMCPEditorCommands::HandleGenerateControlRig: Target=%s"), *SkeletalMeshPath);
+
+    TSharedPtr<FJsonObject> ResultData = MakeShareable(new FJsonObject);
+    ResultData->SetStringField(TEXT("message"), TEXT("Generate Control Rig command received (Stub implementation)"));
+    ResultData->SetStringField(TEXT("skeletal_mesh_path"), SkeletalMeshPath);
+
+    return FEpicUnrealMCPCommonUtils::CreateSuccessResponse(ResultData);
+}
+
+TSharedPtr<FJsonObject> FEpicUnrealMCPEditorCommands::HandleCleanupAnimation(const TSharedPtr<FJsonObject>& Params)
+{
+    FString AnimationPath;
+    if (!Params->TryGetStringField(TEXT("animation_path"), AnimationPath))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'animation_path' parameter"));
+    }
+
+    UE_LOG(LogTemp, Display, TEXT("FEpicUnrealMCPEditorCommands::HandleCleanupAnimation: Target=%s"), *AnimationPath);
+
+    TSharedPtr<FJsonObject> ResultData = MakeShareable(new FJsonObject);
+    ResultData->SetStringField(TEXT("message"), TEXT("Cleanup animation command received (Stub implementation)"));
+    ResultData->SetStringField(TEXT("animation_path"), AnimationPath);
+
+    return FEpicUnrealMCPCommonUtils::CreateSuccessResponse(ResultData);
+}
+
+TSharedPtr<FJsonObject> FEpicUnrealMCPEditorCommands::HandleGenerateProceduralAnim(const TSharedPtr<FJsonObject>& Params)
+{
+    FString ControlRigPath;
+    if (!Params->TryGetStringField(TEXT("control_rig_path"), ControlRigPath))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'control_rig_path' parameter"));
+    }
+
+    UE_LOG(LogTemp, Display, TEXT("FEpicUnrealMCPEditorCommands::HandleGenerateProceduralAnim: Target=%s"), *ControlRigPath);
+
+    TSharedPtr<FJsonObject> ResultData = MakeShareable(new FJsonObject);
+    ResultData->SetStringField(TEXT("message"), TEXT("Generate procedural animation command received (Stub implementation)"));
+    ResultData->SetStringField(TEXT("control_rig_path"), ControlRigPath);
+
+    return FEpicUnrealMCPCommonUtils::CreateSuccessResponse(ResultData);
 }

--- a/Plugins/UnrealMCP/Source/UnrealMCP/Private/EpicUnrealMCPBridge.cpp
+++ b/Plugins/UnrealMCP/Source/UnrealMCP/Private/EpicUnrealMCPBridge.cpp
@@ -329,6 +329,10 @@ namespace
             {TEXT("add_function_output"), 3},
             {TEXT("delete_function"), 3},
             {TEXT("rename_function"), 3},
+            {TEXT("auto_skin_mesh"), 1},
+            {TEXT("generate_control_rig"), 1},
+            {TEXT("cleanup_animation"), 1},
+            {TEXT("generate_procedural_anim"), 1},
         };
         const int32* Found = Router.Find(CommandType);
         return Found ? *Found : -1;

--- a/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPEditorCommands.h
+++ b/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPEditorCommands.h
@@ -100,4 +100,10 @@ private:
     TSharedPtr<FJsonObject> HandleDeleteInstanceSet(const TSharedPtr<FJsonObject>& Params);
     TSharedPtr<FJsonObject> HandleGetInstanceSetState(const TSharedPtr<FJsonObject>& Params);
     TSharedPtr<FJsonObject> HandleListInstanceSets(const TSharedPtr<FJsonObject>& Params);
+
+    // Animation & Rigging commands
+    TSharedPtr<FJsonObject> HandleAutoSkinMesh(const TSharedPtr<FJsonObject>& Params);
+    TSharedPtr<FJsonObject> HandleGenerateControlRig(const TSharedPtr<FJsonObject>& Params);
+    TSharedPtr<FJsonObject> HandleCleanupAnimation(const TSharedPtr<FJsonObject>& Params);
+    TSharedPtr<FJsonObject> HandleGenerateProceduralAnim(const TSharedPtr<FJsonObject>& Params);
 }; 

--- a/Python/pyproject.toml
+++ b/Python/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "fastapi",
   "pydantic>=2.6.1",
   "requests",
-  "PyYAML>=6.0"
+  "PyYAML>=6.0",
 ]
 
 [project.optional-dependencies]

--- a/Python/server/__init__.py
+++ b/Python/server/__init__.py
@@ -25,6 +25,7 @@ def bootstrap():
     from server import blueprint_tools    # noqa: F401
     from server import blueprint_graph_tools  # noqa: F401
     from server import world_building_tools  # noqa: F401
+    from server import animation_tools    # noqa: F401
 
 
 if __name__ == "__main__":

--- a/Python/server/animation_tools.py
+++ b/Python/server/animation_tools.py
@@ -1,0 +1,164 @@
+"""Animation and rigging tools for the Unreal MCP server."""
+
+import logging
+from typing import Dict, Any, Optional, List
+
+from server.core import mcp, get_unreal_connection
+from server.validation import (
+    validate_string, validate_unreal_path,
+    ValidationError, make_validation_error_response_from_exception
+)
+from utils.responses import make_error_response, is_success_response
+
+logger = logging.getLogger("UnrealMCP_Advanced")
+
+
+@mcp.tool()
+def auto_skin_mesh(
+    static_mesh_path: str,
+    skeleton_path: Optional[str] = None,
+    destination_path: Optional[str] = None
+) -> Dict[str, Any]:
+    """Convert a static mesh to a skeletal mesh and apply automatic skinning weights.
+
+    If skeleton_path is provided, it uses that skeleton (e.g., Epic Skeleton).
+    Otherwise, it attempts to generate a basic rig.
+    """
+    try:
+        validate_unreal_path(static_mesh_path, "static_mesh_path")
+        if skeleton_path:
+            validate_unreal_path(skeleton_path, "skeleton_path")
+        if destination_path:
+            validate_unreal_path(destination_path, "destination_path")
+    except ValidationError as e:
+        return make_validation_error_response_from_exception(e)
+
+    unreal = get_unreal_connection()
+    if not unreal:
+        return make_error_response("Failed to connect to Unreal Engine")
+
+    try:
+        params = {"static_mesh_path": static_mesh_path}
+        if skeleton_path:
+            params["skeleton_path"] = skeleton_path
+        if destination_path:
+            params["destination_path"] = destination_path
+
+        response = unreal.send_command("auto_skin_mesh", params)
+        return response or make_error_response("No response from Unreal")
+    except Exception as e:
+        logger.error(f"auto_skin_mesh error: {e}")
+        return make_error_response(str(e))
+
+
+@mcp.tool()
+def generate_control_rig(
+    skeletal_mesh_path: str,
+    destination_path: Optional[str] = None
+) -> Dict[str, Any]:
+    """Generate a Control Rig for a given skeletal mesh.
+
+    This adapts the Control Rig to the bone hierarchy of the skeletal mesh.
+    """
+    try:
+        validate_unreal_path(skeletal_mesh_path, "skeletal_mesh_path")
+        if destination_path:
+            validate_unreal_path(destination_path, "destination_path")
+    except ValidationError as e:
+        return make_validation_error_response_from_exception(e)
+
+    unreal = get_unreal_connection()
+    if not unreal:
+        return make_error_response("Failed to connect to Unreal Engine")
+
+    try:
+        params = {"skeletal_mesh_path": skeletal_mesh_path}
+        if destination_path:
+            params["destination_path"] = destination_path
+
+        response = unreal.send_command("generate_control_rig", params)
+        return response or make_error_response("No response from Unreal")
+    except Exception as e:
+        logger.error(f"generate_control_rig error: {e}")
+        return make_error_response(str(e))
+
+
+@mcp.tool()
+def cleanup_animation(
+    animation_path: str,
+    bone_names: Optional[List[str]] = None,
+    filter_type: str = "Butterworth",
+    cutoff_frequency: float = 15.0
+) -> Dict[str, Any]:
+    """Clean up jitter or interpolation errors in an animation sequence.
+
+    Applies a filter (like Butterworth) to smooth out high-frequency noise.
+    """
+    try:
+        validate_unreal_path(animation_path, "animation_path")
+        validate_string(filter_type, "filter_type")
+    except ValidationError as e:
+        return make_validation_error_response_from_exception(e)
+
+    if bone_names is not None and not isinstance(bone_names, list):
+        return make_error_response("bone_names must be a list of strings")
+
+    unreal = get_unreal_connection()
+    if not unreal:
+        return make_error_response("Failed to connect to Unreal Engine")
+
+    try:
+        params = {
+            "animation_path": animation_path,
+            "filter_type": filter_type,
+            "cutoff_frequency": cutoff_frequency
+        }
+        if bone_names:
+            params["bone_names"] = bone_names
+
+        response = unreal.send_command("cleanup_animation", params)
+        return response or make_error_response("No response from Unreal")
+    except Exception as e:
+        logger.error(f"cleanup_animation error: {e}")
+        return make_error_response(str(e))
+
+
+@mcp.tool()
+def generate_procedural_anim(
+    control_rig_path: str,
+    start_pose: Dict[str, Any],
+    end_pose: Dict[str, Any],
+    duration: float,
+    context_parameters: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """Generate procedural animation interpolation between two poses.
+
+    Uses physics context to generate realistic curves for the Control Rig.
+    """
+    try:
+        validate_unreal_path(control_rig_path, "control_rig_path")
+    except ValidationError as e:
+        return make_validation_error_response_from_exception(e)
+
+    if duration <= 0:
+        return make_error_response("duration must be greater than 0")
+
+    unreal = get_unreal_connection()
+    if not unreal:
+        return make_error_response("Failed to connect to Unreal Engine")
+
+    try:
+        params = {
+            "control_rig_path": control_rig_path,
+            "start_pose": start_pose,
+            "end_pose": end_pose,
+            "duration": duration,
+        }
+        if context_parameters:
+            params["context_parameters"] = context_parameters
+
+        response = unreal.send_command("generate_procedural_anim", params)
+        return response or make_error_response("No response from Unreal")
+    except Exception as e:
+        logger.error(f"generate_procedural_anim error: {e}")
+        return make_error_response(str(e))

--- a/Python/tests/unit/test_tool_registration_and_mapping.py
+++ b/Python/tests/unit/test_tool_registration_and_mapping.py
@@ -348,6 +348,7 @@ class TestPythonToCppCommandMapping:
             "scene_create_sdf_mesh",
             "scene_create_superformula_mesh",
             "scene_create_lsystem_spline",
+            "auto_skin_mesh", "cleanup_animation", "generate_control_rig", "generate_procedural_anim",
         }
         registered = self._collect_registered_tool_names()
         missing = []

--- a/Python/unreal_mcp_server_advanced.py
+++ b/Python/unreal_mcp_server_advanced.py
@@ -66,6 +66,13 @@ from server.material_tools import (
     set_mesh_material_color,
 )
 
+from server.animation_tools import (
+    auto_skin_mesh,
+    generate_control_rig,
+    cleanup_animation,
+    generate_procedural_anim,
+)
+
 from server.world_building_tools import (
     create_pyramid,
     create_wall,
@@ -176,6 +183,10 @@ __all__ = [
     "scene_create_sdf_mesh",
     "scene_create_superformula_mesh",
     "scene_create_lsystem_spline",
+    "auto_skin_mesh",
+    "generate_control_rig",
+    "cleanup_animation",
+    "generate_procedural_anim",
 ]
 
 


### PR DESCRIPTION
This PR implements the framework for advanced 3D animation and rigging tasks, exposing new MCP tools to trigger Unreal Engine Editor API functions for these workflows.

### Added Tools
- `auto_skin_mesh`: Convert Static Mesh to Skeletal Mesh and apply basic skinning weights.
- `generate_control_rig`: Generate a Control Rig for a target Skeletal Mesh.
- `cleanup_animation`: Apply smoothing/filtering (e.g., Butterworth) to an Animation Sequence.
- `generate_procedural_anim`: Generate interpolation curves between given poses for a Control Rig.

### Details
- Defined `@mcp.tool()` handlers in `Python/server/animation_tools.py` with full parameter validation.
- Registered the tools in the Python MCP server entry points (`__init__.py` and `unreal_mcp_server_advanced.py`).
- Mapped commands in `EpicUnrealMCPBridge.cpp` to route the new tools to the editor command group.
- Created C++ stub handlers in `EpicUnrealMCPEditorCommands.cpp` that successfully log and echo back the request parameters.
- Updated python unit tests in `test_tool_registration_and_mapping.py` to cover the new tools.

---
*PR created automatically by Jules for task [3796291937407322944](https://jules.google.com/task/3796291937407322944) started by @neko-jpg*