### PR TITLE
chore(234-stubs W0.5): issue-resolution infra for Waves 1-5

### DIFF
--- a/.github/ISSUE_TEMPLATE/stub_followup.yml
+++ b/.github/ISSUE_TEMPLATE/stub_followup.yml
@@ -1,0 +1,35 @@
+name: 234-stubs follow-up
+description: Track a follow-up that falls out of scope of an existing wave / category issue.
+title: "[234-stubs follow-up] <area>: <short title>"
+labels:
+  - stub-impl
+  - stub-tracker
+body:
+  - type: input
+    id: parent-issue
+    attributes:
+      label: Parent wave / category issue
+      placeholder: "#84"
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What is the residual work this issue tracks?
+    validations:
+      required: true
+  - type: textarea
+    id: dod
+    attributes:
+      label: Definition of Done
+      description: Bullet list of acceptance criteria.
+    validations:
+      required: true
+  - type: textarea
+    id: ue57-api
+    attributes:
+      label: UE 5.7 API references
+      description: |
+        Required if this issue describes an implementation. List the search
+        terms, docs, and headers consulted (AGENTS.md compliance).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,60 @@
+<!--
+234-stubs Wave 0.5 follow-up (umbrella: #69).
+
+If this PR promotes any stub handler to executed:true, keep the
+sections below. The agents-md-pr-check workflow will fail the PR if
+"## Scope reconciliation", "## UE 5.7 API research", or "## Tests" is
+missing while the `stub-impl` label is applied.
+
+For non-stub PRs (docs only, CI tweak, etc.) you can replace the
+template with a single short paragraph.
+-->
+
+Refs #<issue>
+<!-- or, for the final PR that finishes a category: Closes #<issue> -->
+
+## Scope reconciliation
+
+- Issue checklist count:
+- Existing `queued:true` count (this PR before):
+- Already `executed:true` count:
+- Promoted in this PR:
+- Notes on shallow real-impl vs full promotion:
+
+## UE 5.7 API research
+
+- Search terms (e.g. `web_search "UPCGGraph 5.7"`):
+- Official docs / headers checked:
+- Deprecated APIs avoided (must include `UpdateDefaultConfigFile()` if relevant):
+- Config persistence decision (`TryUpdateDefaultConfigFileSafe` / N/A):
+- Module gate(s) used (`WITH_<MODULE>_MCP`):
+
+## Handlers promoted
+
+- [ ] handler_a
+- [ ] handler_b
+
+## Tests
+
+- Unit: `pytest Python/tests/unit -q`
+- Contract: `pytest Python/tests/contract -q`
+- Route audit: `python scripts/audit_route_contracts.py --strict`
+- Queued audit: `python scripts/audit_no_new_queued.py`
+- Live smoke (if applicable): `python scripts/live_e2e_smoke.py --only <case>`
+- Local RunUAT or CI RunUAT: `pwsh -File scripts/run_local_uat_buildplugin.ps1`
+- Log artifact path:
+
+## CHANGELOG
+
+- Fragment: `CHANGELOG.d/<wave>-<category>-<slug>.md`
+- (Do not edit `CHANGELOG.md` directly.)
+
+## Router / Bridge / live_e2e_smoke notes
+
+<!--
+If this PR needs a new entry in EpicUnrealMCPRouter.cpp,
+EpicUnrealMCPBridge.cpp, or scripts/live_e2e_smoke.py, list the
+desired entries here so the reviewer/integrator can fold them in via
+the wave-close PR. Do not edit these shared files from a category PR.
+See docs/dev/shared-file-policy.md.
+-->

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,177 @@
+# 234-stubs Wave 0.5 follow-up (umbrella: #69).
+#
+# Drives .github/workflows/labeler.yml so that PRs touching the
+# UnrealMCP plugin sources or specific stub categories get the right
+# labels automatically. The labels then gate the heavy UE 5.7 build
+# job in ue57-build.yml and let reviewers filter category PRs.
+#
+# Path patterns use the actions/labeler v5 'changed-files' syntax.
+
+ue5.7-build:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Plugins/UnrealMCP/**"
+          - "scripts/run_local_uat_buildplugin.ps1"
+          - ".github/workflows/ue57-build.yml"
+
+stub-impl:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPAiNavExtensionCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPAnimationRiggingCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPChaosCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPDataTableExtensionCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPFoliageCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPGASCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPLandscapeCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPLocalizationCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPMetaSoundCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPMobileXrCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPMovieRenderQueueCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPNetworkingCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPPCGCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPSequencerExtensionCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPSourceControlCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPTestingValidationCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPWaterCommands.cpp"
+
+# Wave 1 (M6)
+stub-cat-anim-rigging:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPAnimationRiggingCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPAnimationRiggingCommands.h"
+          - "Python/server/anim_rigging_tools.py"
+          - "Python/tests/unit/test_anim_rigging_*.py"
+
+stub-cat-landscape:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPLandscapeCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPLandscapeCommands.h"
+          - "Python/server/landscape_tools.py"
+          - "Python/tests/unit/test_landscape_*.py"
+
+# Wave 2 (M7)
+stub-cat-ai-nav-extension:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPAiNavExtensionCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPAiNavExtensionCommands.h"
+          - "Python/server/ai_nav_extension_tools.py"
+          - "Python/tests/unit/test_ai_nav_extension_*.py"
+
+stub-cat-data-table-extension:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPDataTableExtensionCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPDataTableExtensionCommands.h"
+          - "Python/server/data_table_extension_tools.py"
+          - "Python/tests/unit/test_data_table_extension_*.py"
+
+stub-cat-gas:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPGASCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPGASCommands.h"
+          - "Python/server/gas_tools.py"
+          - "Python/tests/unit/test_gas_*.py"
+
+stub-cat-sequencer-extension:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPSequencerExtensionCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPSequencerExtensionCommands.h"
+          - "Python/server/sequencer_extension_tools.py"
+          - "Python/tests/unit/test_sequencer_extension_*.py"
+
+# Wave 3 (M8)
+stub-cat-chaos:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPChaosCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPChaosCommands.h"
+          - "Python/server/chaos_tools.py"
+          - "Python/tests/unit/test_chaos_*.py"
+
+stub-cat-foliage:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPFoliageCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPFoliageCommands.h"
+          - "Python/server/foliage_tools.py"
+          - "Python/tests/unit/test_foliage_*.py"
+
+stub-cat-pcg:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPPCGCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPPCGCommands.h"
+          - "Python/server/pcg_tools.py"
+          - "Python/tests/unit/test_pcg_*.py"
+
+stub-cat-water:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPWaterCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPWaterCommands.h"
+          - "Python/server/water_tools.py"
+          - "Python/tests/unit/test_water_*.py"
+
+# Wave 4 (M9)
+stub-cat-localization:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPLocalizationCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPLocalizationCommands.h"
+          - "Python/server/localization_tools.py"
+          - "Python/tests/unit/test_localization_*.py"
+
+stub-cat-movie-render-queue:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPMovieRenderQueueCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPMovieRenderQueueCommands.h"
+          - "Python/server/movie_render_queue_tools.py"
+          - "Python/tests/unit/test_movie_render_queue_*.py"
+
+stub-cat-networking:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPNetworkingCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPNetworkingCommands.h"
+          - "Python/server/networking_tools.py"
+          - "Python/tests/unit/test_networking_*.py"
+
+stub-cat-source-control:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPSourceControlCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPSourceControlCommands.h"
+          - "Python/server/source_control_tools.py"
+          - "Python/tests/unit/test_source_control_*.py"
+
+# Wave 5 (M10)
+stub-cat-metasound:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPMetaSoundCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPMetaSoundCommands.h"
+          - "Python/server/metasound_tools.py"
+          - "Python/tests/unit/test_metasound_*.py"
+
+stub-cat-mobile-xr:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPMobileXrCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPMobileXrCommands.h"
+          - "Python/server/mobile_xr_tools.py"
+          - "Python/tests/unit/test_mobile_xr_*.py"
+
+stub-cat-testing-validation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPTestingValidationCommands.cpp"
+          - "Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPTestingValidationCommands.h"
+          - "Python/server/testing_validation_tools.py"
+          - "Python/tests/unit/test_testing_validation_*.py"

--- a/.github/workflows/agents-md-pr-check.yml
+++ b/.github/workflows/agents-md-pr-check.yml
@@ -1,0 +1,49 @@
+name: AGENTS.md PR body check (234-stubs)
+
+# 234-stubs Wave 0.5 follow-up (umbrella: #69).
+#
+# Any PR labelled `stub-impl` (set by the labeler workflow when a
+# stub category C++ file changes) must include the AGENTS.md-mandated
+# `## UE 5.7 API research` section in its body. This makes the
+# "no learned-data API guessing" rule enforceable in CI instead of
+# relying on reviewer memory.
+#
+# Body sections looked up:
+#   * "## UE 5.7 API research"
+#   * "## Scope reconciliation"
+#   * "## Tests"
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  enforce-research-section:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'stub-impl')
+    steps:
+      - name: Verify required PR body sections
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = (context.payload.pull_request.body || '').replace(/\r\n/g, '\n');
+            const required = [
+              '## Scope reconciliation',
+              '## UE 5.7 API research',
+              '## Tests',
+            ];
+            const missing = required.filter((h) => !body.includes(h));
+            if (missing.length > 0) {
+              core.setFailed(
+                'PR body is missing required AGENTS.md sections: ' +
+                missing.join(', ') +
+                '. See docs/dev/shared-file-policy.md and ' +
+                '.github/PULL_REQUEST_TEMPLATE.md.'
+              );
+              return;
+            }
+            core.info('All required PR body sections present.');

--- a/.github/workflows/agents-md-pr-check.yml
+++ b/.github/workflows/agents-md-pr-check.yml
@@ -1,49 +1,77 @@
-name: AGENTS.md PR body check (234-stubs)
+﻿name: AGENTS.md PR body check (234-stubs)
 
 # 234-stubs Wave 0.5 follow-up (umbrella: #69).
 #
-# Any PR labelled `stub-impl` (set by the labeler workflow when a
-# stub category C++ file changes) must include the AGENTS.md-mandated
-# `## UE 5.7 API research` section in its body. This makes the
-# "no learned-data API guessing" rule enforceable in CI instead of
-# relying on reviewer memory.
+# Always runs against every PR so the resulting check status is
+# reportable for branch protection. Inside the job, we inspect the PR
+# labels at runtime and short-circuit if `stub-impl` is not present.
+# This is preferred over a job-level `if:` because GitHub treats a
+# skipped check as "no status reported", which cannot be required by
+# branch protection.
 #
-# Body sections looked up:
-#   * "## UE 5.7 API research"
+# Required body sections:
 #   * "## Scope reconciliation"
+#   * "## UE 5.7 API research"
 #   * "## Tests"
 
 on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened, labeled, unlabeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to re-check"
+        required: true
+        type: number
 
 permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: agents-md-pr-check-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   enforce-research-section:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'stub-impl')
     steps:
       - name: Verify required PR body sections
         uses: actions/github-script@v7
         with:
           script: |
-            const body = (context.payload.pull_request.body || '').replace(/\r\n/g, '\n');
+            const isDispatch = context.eventName === "workflow_dispatch";
+            let pr;
+            if (isDispatch) {
+              const { data } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: Number(context.payload.inputs.pr_number),
+              });
+              pr = data;
+            } else {
+              pr = context.payload.pull_request;
+            }
+            const labels = (pr.labels || []).map((l) => l.name);
+            core.info(`PR #${pr.number} labels: ${labels.join(", ") || "(none)"}`);
+            if (!labels.includes("stub-impl")) {
+              core.info("PR is not labelled stub-impl; AGENTS.md body sections not required.");
+              return;
+            }
+            const body = (pr.body || "").replace(/\r\n/g, "\n");
             const required = [
-              '## Scope reconciliation',
-              '## UE 5.7 API research',
-              '## Tests',
+              "## Scope reconciliation",
+              "## UE 5.7 API research",
+              "## Tests",
             ];
             const missing = required.filter((h) => !body.includes(h));
             if (missing.length > 0) {
               core.setFailed(
-                'PR body is missing required AGENTS.md sections: ' +
-                missing.join(', ') +
-                '. See docs/dev/shared-file-policy.md and ' +
-                '.github/PULL_REQUEST_TEMPLATE.md.'
+                "PR body is missing required AGENTS.md sections: " +
+                  missing.join(", ") +
+                  ". See docs/dev/shared-file-policy.md and " +
+                  ".github/PULL_REQUEST_TEMPLATE.md."
               );
               return;
             }
-            core.info('All required PR body sections present.');
+            core.info("All required AGENTS.md PR body sections present.");

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,4 +1,4 @@
-name: PR labeler (234-stubs)
+﻿name: PR labeler (234-stubs)
 
 # 234-stubs Wave 0.5 follow-up (umbrella: #69).
 #
@@ -6,16 +6,21 @@ name: PR labeler (234-stubs)
 # that:
 #   * `ue5.7-build` triggers the gated RunUAT BuildPlugin job in
 #     .github/workflows/ue57-build.yml.
-#   * `stub-impl` triggers the agents-md-pr-check workflow.
+#   * `stub-impl` triggers the agents-md-pr-check workflow logic.
 #   * `stub-cat-*` lets reviewers slice PRs by category.
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+    types: [opened, synchronize, reopened, edited]
+  workflow_dispatch:
 
 permissions:
   contents: read
   pull-requests: write
+
+concurrency:
+  group: labeler-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   labeler:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,28 @@
+name: PR labeler (234-stubs)
+
+# 234-stubs Wave 0.5 follow-up (umbrella: #69).
+#
+# Reads .github/labeler.yml and applies path-based labels to PRs so
+# that:
+#   * `ue5.7-build` triggers the gated RunUAT BuildPlugin job in
+#     .github/workflows/ue57-build.yml.
+#   * `stub-impl` triggers the agents-md-pr-check workflow.
+#   * `stub-cat-*` lets reviewers slice PRs by category.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: false

--- a/.github/workflows/queued-audit.yml
+++ b/.github/workflows/queued-audit.yml
@@ -1,4 +1,4 @@
-name: queued:true regression audit (234-stubs)
+﻿name: queued:true regression audit (234-stubs)
 
 # 234-stubs Wave 0.5 follow-up (umbrella: #69).
 #
@@ -14,9 +14,14 @@ name: queued:true regression audit (234-stubs)
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
+
+concurrency:
+  group: queued-audit-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   audit:

--- a/.github/workflows/queued-audit.yml
+++ b/.github/workflows/queued-audit.yml
@@ -1,0 +1,32 @@
+name: queued:true regression audit (234-stubs)
+
+# 234-stubs Wave 0.5 follow-up (umbrella: #69).
+#
+# Replaces the warn-only `Queued regression grep` step that lives in
+# ue57-build.yml with a blocking check rooted in
+# artifacts/queued_baseline.json. Any PR that *adds* a new
+# `SetBoolField(TEXT("queued"), true)` site fails this job, which is
+# required for merge.
+#
+# The baseline can only be lowered (intentional wave-close PR) via
+# `python scripts/audit_no_new_queued.py --update-baseline`.
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Show current queued counts
+        run: python scripts/audit_no_new_queued.py --print
+      - name: Enforce no-new-queued baseline
+        run: python scripts/audit_no_new_queued.py

--- a/.gitignore
+++ b/.gitignore
@@ -177,5 +177,7 @@ FlopperamUnrealMCP/Content/Tests/MCP_Runtime/
 # Generated source-built UnrealMCP plugin copy; canonical source is Plugins/UnrealMCP/.
 FlopperamUnrealMCP/Plugins/
 
-# Generated test/report artifacts
-artifacts/
+# Generated test/report artifacts (queued_baseline.json is versioned)
+/artifacts/*
+!/artifacts/queued_baseline.json
+

--- a/CHANGELOG.d/README.md
+++ b/CHANGELOG.d/README.md
@@ -1,0 +1,44 @@
+# CHANGELOG fragments
+
+234-stubs Wave 0.5 follow-up (umbrella: #69).
+
+To avoid serializing every Wave 1-5 PR through the 100+ KiB `CHANGELOG.md`,
+each PR drops a small fragment in this directory and the wave-close PR
+(reviewer/integrator) folds them into `CHANGELOG.md`.
+
+## Naming
+
+```
+CHANGELOG.d/<wave>-<category>-<short-slug>.md
+```
+
+Examples:
+
+- `w1-anim-rigging-control-rig-bone.md`
+- `w2-gas-add-attribute.md`
+- `w3-pcg-graph-add-node-part1.md`
+
+## Fragment shape
+
+```md
+### <category>: <handler list summary>
+
+- Issue: #<n>
+- PR: #<n>
+- Wave: W<n>
+- Handlers promoted: <count>
+- New `executed: true` cases: <list>
+- Build verified: local RunUAT / self-hosted CI / both
+```
+
+## Fold-in command
+
+Run from the wave-close PR branch:
+
+```pwsh
+python scripts/fold_changelog_fragments.py --wave 3
+```
+
+The fold-in script appends each fragment under
+`## [Unreleased] > 234-stubs > Wave <n>` in `CHANGELOG.md` and removes
+the originals in the same commit.

--- a/CHANGELOG.d/w0.5-issue-resolution-infra.md
+++ b/CHANGELOG.d/w0.5-issue-resolution-infra.md
@@ -1,0 +1,21 @@
+﻿### w0.5: issue-resolution infra
+
+- Issue: refs #69
+- PR: codex/w0-followup-issue-resolution-infra
+- Wave: W0.5
+- Handlers promoted: 0
+- New `executed: true` cases: -
+- Build verified: scripted-only (no `RunUAT BuildPlugin` because no C++ touched)
+
+Adds the parallel-PR safety net for Waves 1-5:
+
+- `scripts/audit_no_new_queued.py` + `artifacts/queued_baseline.json` (blocking).
+- `scripts/run_local_uat_buildplugin.ps1` (deterministic local UE build log path).
+- `scripts/fold_changelog_fragments.py` + `CHANGELOG.d/` (this fragment is the first).
+- `.github/labeler.yml`, `.github/workflows/labeler.yml`,
+  `.github/workflows/agents-md-pr-check.yml`,
+  `.github/workflows/queued-audit.yml`.
+- `.github/PULL_REQUEST_TEMPLATE.md` + `.github/ISSUE_TEMPLATE/stub_followup.yml`.
+- `docs/dev/shared-file-policy.md`, `docs/dev/runbooks/{issue-resolution,wave-close,README}.md`.
+- Spike doc placeholders for #84, #89, #91, #95, #96, #99.
+- Plan amendment in `docs/implementation-plan-234-stubs.md` (sections 13-17).

--- a/CHANGELOG.d/w0.5-refinements-105.md
+++ b/CHANGELOG.d/w0.5-refinements-105.md
@@ -1,0 +1,27 @@
+﻿### w0.5 refinements: hardening on top of #105
+
+- Issue: refs #69
+- PR: codex-w0-followup-issue-resolution-infra (refinement commit on top of original W0.5)
+- Wave: W0.5
+- Handlers promoted: 0
+- New `executed: true` cases: -
+- Build verified: scripted-only (no C++ touched)
+
+Tightens the W0.5 infra so it can stand up as branch-protection-grade gates:
+
+- `.github/workflows/agents-md-pr-check.yml` now always runs and inspects the
+  `stub-impl` label inside the script body. The previous job-level `if:` made
+  the check report as "skipped", which branch protection cannot Require.
+- All three new workflows (`labeler.yml`, `agents-md-pr-check.yml`,
+  `queued-audit.yml`) gain a `concurrency:` group and `workflow_dispatch`
+  trigger so reviewers have a manual recovery path when Actions is backed up.
+- Created the missing `ue5.7-build` repo label so `actions/labeler@v5`
+  does not fail on its first run and the gated UE 5.7 RunUAT job can fire.
+- `scripts/fold_changelog_fragments.py` gains `--all-waves` for the
+  eventual umbrella-close PR (#69).
+- `Python/tests/unit/test_w0_followup_workflow_hardening.py` locks the
+  invariants in place (`pytest tests/unit -k w0_followup` -> 23 passed).
+- `docs/dev/runbooks/wave-close.md` sections 8 & 9 document the manual
+  `gh workflow run` recovery and the umbrella-close steps.
+- `docs/implementation-plan-234-stubs.md` section 18 records the
+  refinements for the next reviewer.

--- a/Python/tests/unit/test_audit_no_new_queued.py
+++ b/Python/tests/unit/test_audit_no_new_queued.py
@@ -1,0 +1,114 @@
+"""234-stubs Wave 0.5 follow-up (umbrella: #69).
+
+Unit tests for scripts/audit_no_new_queued.py. The tests import the script
+as a module so the regex, baseline I/O, and diff logic can be exercised
+without spawning a subprocess.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "audit_no_new_queued.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("audit_no_new_queued", SCRIPT)
+    assert spec and spec.loader, "could not load audit_no_new_queued.py"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def audit_mod():
+    return _load_module()
+
+
+def test_pattern_matches_canonical_queued_line(audit_mod):
+    src = 'Data->SetBoolField(TEXT("queued"), true);'
+    assert audit_mod.QUEUED_PATTERN.search(src) is not None
+
+
+def test_pattern_ignores_executed_line(audit_mod):
+    src = 'Data->SetBoolField(TEXT("executed"), true);'
+    assert audit_mod.QUEUED_PATTERN.search(src) is None
+
+
+def test_pattern_ignores_queued_false(audit_mod):
+    src = 'Data->SetBoolField(TEXT("queued"), false);'
+    assert audit_mod.QUEUED_PATTERN.search(src) is None
+
+
+def test_diff_passes_when_counts_match(audit_mod):
+    current = {"A.cpp": 3, "B.cpp": 1}
+    baseline = {"total": 4, "per_file": {"A.cpp": 3, "B.cpp": 1}}
+    assert audit_mod.diff_against_baseline(current, baseline) == []
+
+
+def test_diff_passes_when_counts_drop(audit_mod):
+    current = {"A.cpp": 2, "B.cpp": 1}
+    baseline = {"total": 4, "per_file": {"A.cpp": 3, "B.cpp": 1}}
+    assert audit_mod.diff_against_baseline(current, baseline) == []
+
+
+def test_diff_flags_total_regression(audit_mod):
+    current = {"A.cpp": 4, "B.cpp": 1}
+    baseline = {"total": 4, "per_file": {"A.cpp": 3, "B.cpp": 1}}
+    problems = audit_mod.diff_against_baseline(current, baseline)
+    assert any("total queued:true regressed" in p for p in problems)
+
+
+def test_diff_flags_per_file_regression(audit_mod):
+    current = {"A.cpp": 5}
+    baseline = {"total": 5, "per_file": {"A.cpp": 3, "B.cpp": 2}}
+    problems = audit_mod.diff_against_baseline(current, baseline)
+    assert any("A.cpp: 3 -> 5" in p for p in problems)
+
+
+def test_diff_flags_new_file_with_queued(audit_mod):
+    current = {"A.cpp": 3, "Newcomer.cpp": 1}
+    baseline = {"total": 3, "per_file": {"A.cpp": 3}}
+    problems = audit_mod.diff_against_baseline(current, baseline)
+    assert any("Newcomer.cpp: 0 -> 1" in p for p in problems)
+
+
+def test_write_baseline_roundtrip(tmp_path, audit_mod):
+    target = tmp_path / "queued_baseline.json"
+    counts = {"Z.cpp": 7, "A.cpp": 2}
+    audit_mod.write_baseline(target, counts)
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload["total"] == 9
+    assert list(payload["per_file"].keys()) == ["A.cpp", "Z.cpp"]
+
+
+def test_load_baseline_rejects_missing_per_file(tmp_path, audit_mod):
+    target = tmp_path / "bad.json"
+    target.write_text(json.dumps({"total": 0}), encoding="utf-8")
+    with pytest.raises(SystemExit):
+        audit_mod.load_baseline(target)
+
+
+def test_load_baseline_tolerates_utf8_bom(tmp_path, audit_mod):
+    target = tmp_path / "bom.json"
+    payload = {"schema": 1, "total": 0, "per_file": {}}
+    target.write_text(json.dumps(payload), encoding="utf-8-sig")
+    assert audit_mod.load_baseline(target)["per_file"] == {}
+
+
+def test_real_baseline_matches_current_counts(audit_mod):
+    """The committed baseline must match the current tree state.
+
+    Wave 1+ category PRs should *decrease* this count and rerun
+    `--update-baseline` only from a wave-close PR.
+    """
+    current = audit_mod.count_queued_per_file()
+    baseline_path = REPO_ROOT / "artifacts" / "queued_baseline.json"
+    baseline = audit_mod.load_baseline(baseline_path)
+    assert audit_mod.diff_against_baseline(current, baseline) == []

--- a/Python/tests/unit/test_fold_changelog_fragments.py
+++ b/Python/tests/unit/test_fold_changelog_fragments.py
@@ -99,3 +99,24 @@ def test_ignores_readme_and_gitkeep(tmp_path, monkeypatch, fold_mod):
     rc = fold_mod.fold(1)
     assert rc == 0
     assert not changelog.exists()
+
+def test_all_waves_runs_every_wave(tmp_path, monkeypatch, fold_mod):
+    changelog, fragment_dir = _set_paths(monkeypatch, fold_mod, tmp_path)
+    (fragment_dir / "w1-foo.md").write_text("- w1", encoding="utf-8")
+    (fragment_dir / "w3-bar.md").write_text("- w3", encoding="utf-8")
+    (fragment_dir / "w5-baz.md").write_text("- w5", encoding="utf-8")
+
+    rc = fold_mod.main(["--all-waves"])
+    assert rc == 0
+
+    text = changelog.read_text(encoding="utf-8")
+    for heading in ("### 234-stubs Wave 1", "### 234-stubs Wave 3", "### 234-stubs Wave 5"):
+        assert heading in text
+    assert not list(fragment_dir.glob("w[1-5]-*.md"))
+
+
+def test_all_waves_and_wave_are_mutually_exclusive(fold_mod):
+    import pytest as _pt
+    with _pt.raises(SystemExit):
+        fold_mod.main(["--all-waves", "--wave", "1"])
+

--- a/Python/tests/unit/test_fold_changelog_fragments.py
+++ b/Python/tests/unit/test_fold_changelog_fragments.py
@@ -1,0 +1,101 @@
+"""234-stubs Wave 0.5 follow-up (umbrella: #69).
+
+Unit tests for scripts/fold_changelog_fragments.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "fold_changelog_fragments.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "fold_changelog_fragments", SCRIPT
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def fold_mod():
+    return _load_module()
+
+
+def _set_paths(monkeypatch, mod, tmp_path):
+    changelog = tmp_path / "CHANGELOG.md"
+    fragment_dir = tmp_path / "CHANGELOG.d"
+    fragment_dir.mkdir()
+    monkeypatch.setattr(mod, "CHANGELOG", changelog)
+    monkeypatch.setattr(mod, "FRAGMENT_DIR", fragment_dir)
+    return changelog, fragment_dir
+
+
+def test_fold_creates_unreleased_and_wave_section(tmp_path, monkeypatch, fold_mod):
+    changelog, fragment_dir = _set_paths(monkeypatch, fold_mod, tmp_path)
+    (fragment_dir / "w1-anim-rigging-test.md").write_text(
+        "### anim-rigging: control_rig_bone\n\n- Promoted: 1\n",
+        encoding="utf-8",
+    )
+
+    rc = fold_mod.fold(1)
+    assert rc == 0
+
+    text = changelog.read_text(encoding="utf-8")
+    assert "## [Unreleased]" in text
+    assert "### 234-stubs Wave 1" in text
+    assert "control_rig_bone" in text
+    assert not list(fragment_dir.glob("w1-*.md"))
+
+
+def test_fold_skips_other_waves(tmp_path, monkeypatch, fold_mod):
+    changelog, fragment_dir = _set_paths(monkeypatch, fold_mod, tmp_path)
+    (fragment_dir / "w1-foo.md").write_text("- w1", encoding="utf-8")
+    (fragment_dir / "w2-bar.md").write_text("- w2", encoding="utf-8")
+
+    fold_mod.fold(1)
+    fold_mod.fold(2)
+
+    text = changelog.read_text(encoding="utf-8")
+    assert "### 234-stubs Wave 1" in text
+    assert "### 234-stubs Wave 2" in text
+    assert "w1" in text and "w2" in text
+
+
+def test_fold_appends_to_existing_wave_section(tmp_path, monkeypatch, fold_mod):
+    changelog, fragment_dir = _set_paths(monkeypatch, fold_mod, tmp_path)
+    changelog.write_text(
+        "## [Unreleased]\n\n### 234-stubs Wave 1\n\n- existing\n",
+        encoding="utf-8",
+    )
+    (fragment_dir / "w1-second.md").write_text("- second", encoding="utf-8")
+
+    fold_mod.fold(1)
+    text = changelog.read_text(encoding="utf-8")
+    assert "existing" in text and "second" in text
+    assert text.count("### 234-stubs Wave 1") == 1
+
+
+def test_dry_run_keeps_fragments(tmp_path, monkeypatch, fold_mod):
+    changelog, fragment_dir = _set_paths(monkeypatch, fold_mod, tmp_path)
+    (fragment_dir / "w1-foo.md").write_text("- w1", encoding="utf-8")
+    fold_mod.fold(1, dry_run=True)
+    assert (fragment_dir / "w1-foo.md").exists()
+    assert not changelog.exists()
+
+
+def test_ignores_readme_and_gitkeep(tmp_path, monkeypatch, fold_mod):
+    changelog, fragment_dir = _set_paths(monkeypatch, fold_mod, tmp_path)
+    (fragment_dir / "README.md").write_text("doc", encoding="utf-8")
+    (fragment_dir / ".gitkeep").write_text("", encoding="utf-8")
+    rc = fold_mod.fold(1)
+    assert rc == 0
+    assert not changelog.exists()

--- a/Python/tests/unit/test_w0_followup_artifacts.py
+++ b/Python/tests/unit/test_w0_followup_artifacts.py
@@ -1,0 +1,101 @@
+"""234-stubs Wave 0.5 follow-up (umbrella: #69).
+
+Static sanity checks that every artifact created by the W0.5 PR is
+present and conforms to the contract that the rest of the wave-1+
+machinery depends on. Treat these as canary tests: if you intentionally
+remove an artifact, also remove its check here.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "scripts/audit_no_new_queued.py",
+        "scripts/run_local_uat_buildplugin.ps1",
+        "scripts/fold_changelog_fragments.py",
+        "artifacts/queued_baseline.json",
+        ".github/labeler.yml",
+        ".github/workflows/labeler.yml",
+        ".github/workflows/agents-md-pr-check.yml",
+        ".github/workflows/queued-audit.yml",
+        ".github/PULL_REQUEST_TEMPLATE.md",
+        ".github/ISSUE_TEMPLATE/stub_followup.yml",
+        "docs/dev/shared-file-policy.md",
+        "CHANGELOG.d/README.md",
+    ],
+)
+def test_artifact_present(relative_path: str):
+    p = REPO_ROOT / relative_path
+    assert p.exists(), f"missing W0.5 artifact: {relative_path}"
+
+
+def test_queued_baseline_schema():
+    payload = json.loads(
+        (REPO_ROOT / "artifacts" / "queued_baseline.json").read_text(encoding="utf-8")
+    )
+    assert payload.get("schema") == 1
+    assert isinstance(payload.get("per_file"), dict)
+    assert payload["per_file"], "baseline must list at least one file"
+    assert payload.get("total") == sum(payload["per_file"].values())
+
+
+def test_labeler_lists_every_stub_category():
+    text = (REPO_ROOT / ".github" / "labeler.yml").read_text(encoding="utf-8")
+    categories = [
+        "EpicUnrealMCPAiNavExtensionCommands.cpp",
+        "EpicUnrealMCPAnimationRiggingCommands.cpp",
+        "EpicUnrealMCPChaosCommands.cpp",
+        "EpicUnrealMCPDataTableExtensionCommands.cpp",
+        "EpicUnrealMCPFoliageCommands.cpp",
+        "EpicUnrealMCPGASCommands.cpp",
+        "EpicUnrealMCPLandscapeCommands.cpp",
+        "EpicUnrealMCPLocalizationCommands.cpp",
+        "EpicUnrealMCPMetaSoundCommands.cpp",
+        "EpicUnrealMCPMobileXrCommands.cpp",
+        "EpicUnrealMCPMovieRenderQueueCommands.cpp",
+        "EpicUnrealMCPNetworkingCommands.cpp",
+        "EpicUnrealMCPPCGCommands.cpp",
+        "EpicUnrealMCPSequencerExtensionCommands.cpp",
+        "EpicUnrealMCPSourceControlCommands.cpp",
+        "EpicUnrealMCPTestingValidationCommands.cpp",
+        "EpicUnrealMCPWaterCommands.cpp",
+    ]
+    for name in categories:
+        assert name in text, f"labeler.yml missing entry for {name}"
+
+
+def test_pr_template_has_required_headers():
+    text = (REPO_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md").read_text(
+        encoding="utf-8"
+    )
+    for header in (
+        "## Scope reconciliation",
+        "## UE 5.7 API research",
+        "## Tests",
+        "## CHANGELOG",
+    ):
+        assert header in text, f"PR template missing header: {header}"
+
+
+def test_shared_file_policy_mentions_each_shared_file():
+    text = (REPO_ROOT / "docs" / "dev" / "shared-file-policy.md").read_text(
+        encoding="utf-8"
+    )
+    for shared in (
+        "EpicUnrealMCPRouter.cpp",
+        "EpicUnrealMCPBridge.cpp",
+        "scripts/live_e2e_smoke.py",
+        "CHANGELOG.md",
+        "artifacts/queued_baseline.json",
+    ):
+        assert shared in text, f"shared-file policy missing: {shared}"

--- a/Python/tests/unit/test_w0_followup_workflow_hardening.py
+++ b/Python/tests/unit/test_w0_followup_workflow_hardening.py
@@ -1,0 +1,118 @@
+﻿"""234-stubs Wave 0.5 follow-up refinements (umbrella: #69).
+
+Regression tests that lock in the W0.5 hardening decisions made on top
+of PR #105:
+
+- ``agents-md-pr-check.yml`` must always run (no job-level skip on
+  ``stub-impl``); the label check moves inside the step so the job
+  status is reportable for branch protection.
+- ``queued-audit.yml`` must declare a ``concurrency`` group so duplicate
+  pushes do not race.
+- ``labeler.yml`` must publish ``stub-impl`` whenever a category cpp
+  file is touched (otherwise ``agents-md-pr-check`` is never wired up).
+- ``ue5.7-build`` label is the trigger for the gated UE 5.7 RunUAT job;
+  if it is missing from ``labeler.yml`` the build matrix can never fire.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - dev env always has PyYAML via uv
+    yaml = None  # type: ignore[assignment]
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WF_DIR = REPO_ROOT / ".github" / "workflows"
+
+
+pytestmark = pytest.mark.skipif(yaml is None, reason="PyYAML not installed")
+
+
+def _load(name: str) -> dict:
+    return yaml.safe_load((WF_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_agents_md_pr_check_runs_unconditionally():
+    """The job must not have a top-level ``if: contains(stub-impl)`` guard."""
+    text = (WF_DIR / "agents-md-pr-check.yml").read_text(encoding="utf-8")
+    # If the job-level guard is back the workflow becomes a "skipped"
+    # check that branch protection cannot require.
+    assert "if: contains(github.event.pull_request.labels.*.name, 'stub-impl')" not in text
+    # The runtime guard must still exist inside the script body.
+    assert "labels.includes(\"stub-impl\")" in text or "stub-impl" in text
+
+
+def test_agents_md_pr_check_supports_workflow_dispatch():
+    data = _load("agents-md-pr-check.yml")
+    on = data.get(True) or data.get("on")
+    assert isinstance(on, dict)
+    assert "workflow_dispatch" in on
+    dispatch = on["workflow_dispatch"]
+    assert isinstance(dispatch, dict) and "inputs" in dispatch
+    assert "pr_number" in dispatch["inputs"]
+
+
+def test_agents_md_pr_check_has_concurrency_group():
+    data = _load("agents-md-pr-check.yml")
+    assert "concurrency" in data
+    assert data["concurrency"].get("cancel-in-progress") is True
+
+
+def test_queued_audit_has_concurrency_and_dispatch():
+    data = _load("queued-audit.yml")
+    on = data.get(True) or data.get("on")
+    assert "workflow_dispatch" in on
+    assert "concurrency" in data
+    assert "cancel-in-progress" in data["concurrency"]
+
+
+def test_labeler_workflow_dispatchable():
+    data = _load("labeler.yml")
+    on = data.get(True) or data.get("on")
+    assert "workflow_dispatch" in on
+    assert "concurrency" in data
+
+
+def test_labeler_config_lists_ue57_build_label():
+    text = (REPO_ROOT / ".github" / "labeler.yml").read_text(encoding="utf-8")
+    assert re.search(r"^ue5\.7-build:\s*$", text, re.MULTILINE), text
+    assert "stub-impl:" in text
+
+
+def test_labeler_config_has_one_cat_label_per_category_cpp():
+    text = (REPO_ROOT / ".github" / "labeler.yml").read_text(encoding="utf-8")
+    pairs = {
+        "EpicUnrealMCPAiNavExtensionCommands.cpp": "stub-cat-ai-nav-extension",
+        "EpicUnrealMCPAnimationRiggingCommands.cpp": "stub-cat-anim-rigging",
+        "EpicUnrealMCPChaosCommands.cpp": "stub-cat-chaos",
+        "EpicUnrealMCPDataTableExtensionCommands.cpp": "stub-cat-data-table-extension",
+        "EpicUnrealMCPFoliageCommands.cpp": "stub-cat-foliage",
+        "EpicUnrealMCPGASCommands.cpp": "stub-cat-gas",
+        "EpicUnrealMCPLandscapeCommands.cpp": "stub-cat-landscape",
+        "EpicUnrealMCPLocalizationCommands.cpp": "stub-cat-localization",
+        "EpicUnrealMCPMetaSoundCommands.cpp": "stub-cat-metasound",
+        "EpicUnrealMCPMobileXrCommands.cpp": "stub-cat-mobile-xr",
+        "EpicUnrealMCPMovieRenderQueueCommands.cpp": "stub-cat-movie-render-queue",
+        "EpicUnrealMCPNetworkingCommands.cpp": "stub-cat-networking",
+        "EpicUnrealMCPPCGCommands.cpp": "stub-cat-pcg",
+        "EpicUnrealMCPSequencerExtensionCommands.cpp": "stub-cat-sequencer-extension",
+        "EpicUnrealMCPSourceControlCommands.cpp": "stub-cat-source-control",
+        "EpicUnrealMCPTestingValidationCommands.cpp": "stub-cat-testing-validation",
+        "EpicUnrealMCPWaterCommands.cpp": "stub-cat-water",
+    }
+    for cpp, label in pairs.items():
+        block_match = re.search(rf"^{re.escape(label)}:\s*$", text, re.MULTILINE)
+        assert block_match, f"labeler.yml missing block: {label}"
+        # The block must include the cpp filename glob.
+        # Find the slice of text from this label to the next top-level label or EOF.
+        start = block_match.end()
+        next_label = re.search(r"^[a-z][a-z0-9._-]*:\s*$", text[start:], re.MULTILINE)
+        end = start + next_label.start() if next_label else len(text)
+        block = text[start:end]
+        assert cpp in block, f"{label} block does not reference {cpp}"

--- a/artifacts/queued_baseline.json
+++ b/artifacts/queued_baseline.json
@@ -1,0 +1,24 @@
+{
+  "schema": 1,
+  "generated_utc": "2026-05-23T11:21:01Z",
+  "total": 226,
+  "per_file": {
+    "EpicUnrealMCPAiNavExtensionCommands.cpp": 23,
+    "EpicUnrealMCPAnimationRiggingCommands.cpp": 1,
+    "EpicUnrealMCPChaosCommands.cpp": 19,
+    "EpicUnrealMCPDataTableExtensionCommands.cpp": 9,
+    "EpicUnrealMCPFoliageCommands.cpp": 20,
+    "EpicUnrealMCPGASCommands.cpp": 16,
+    "EpicUnrealMCPLandscapeCommands.cpp": 1,
+    "EpicUnrealMCPLocalizationCommands.cpp": 10,
+    "EpicUnrealMCPMetaSoundCommands.cpp": 7,
+    "EpicUnrealMCPMobileXrCommands.cpp": 14,
+    "EpicUnrealMCPMovieRenderQueueCommands.cpp": 21,
+    "EpicUnrealMCPNetworkingCommands.cpp": 21,
+    "EpicUnrealMCPPCGCommands.cpp": 20,
+    "EpicUnrealMCPSequencerExtensionCommands.cpp": 6,
+    "EpicUnrealMCPSourceControlCommands.cpp": 13,
+    "EpicUnrealMCPTestingValidationCommands.cpp": 10,
+    "EpicUnrealMCPWaterCommands.cpp": 15
+  }
+}

--- a/docs/dev/runbooks/README.md
+++ b/docs/dev/runbooks/README.md
@@ -1,0 +1,23 @@
+﻿# Runbooks index — 234-stubs Waves 1-5
+
+234-stubs Wave 0.5 follow-up (umbrella: #69).
+
+| Runbook | When to use |
+|---|---|
+| [issue-resolution.md](./issue-resolution.md) | A worker is taking a category stub issue from open to merged. |
+| [wave-close.md](./wave-close.md) | The reviewer/integrator is closing a wave roadmap issue (#78 / #83 / #88 / #93 / #98). |
+
+Supporting docs:
+
+- `../shared-file-policy.md` — list of files no category PR may edit.
+- `../../implementation-plan-234-stubs.md` — wave / category roadmap and DoD.
+- `../../spike/<category>-ue57.md` — pre-impl spike notes for high-risk categories.
+
+CI surface used by these runbooks:
+
+- `.github/workflows/labeler.yml` — auto-labels PRs.
+- `.github/workflows/agents-md-pr-check.yml` — enforces PR body sections on `stub-impl` PRs.
+- `.github/workflows/queued-audit.yml` — blocks any PR that increases `queued: true`.
+- `.github/workflows/ue57-build.yml` — runs `RunUAT BuildPlugin` on self-hosted UE 5.7 runners when `ue5.7-build` label is present.
+- `.github/workflows/route-contract-audit.yml` — drift between Python / Rust / Cpp command layers.
+- `.github/workflows/python-tests.yml` — unit + contract + envelope helper smoke.

--- a/docs/dev/runbooks/issue-resolution.md
+++ b/docs/dev/runbooks/issue-resolution.md
@@ -1,0 +1,138 @@
+# 234-stubs Issue Resolution Runbook
+
+234-stubs Wave 0.5 follow-up (umbrella: #69).
+
+Single-file recipe for taking a stub category issue from "open" to
+"closed" without colliding with parallel workers. Read this once, then
+keep it next to the PR you are about to open.
+
+## 1. Pick a category
+
+Pick an open issue from
+`https://github.com/neko-jpg/unreal-engine-mcp/issues?q=is%3Aopen+label%3Astub-impl`.
+
+Reconcile the *user-declared* stub count with the *current* `queued: true`
+grep count:
+
+```pwsh
+python scripts\audit_no_new_queued.py --print
+```
+
+For each category, the printed count and the count in the issue title
+should agree. If they don't, copy the delta into the *Scope reconciliation*
+section of the PR body so reviewers can see whether you are doing a full
+promotion or only finishing the residual handlers.
+
+## 2. UE 5.7 API research (mandatory)
+
+AGENTS.md requires you to verify every API call against UE 5.7 before
+writing C++. The PR template's `## UE 5.7 API research` section is
+enforced by `.github/workflows/agents-md-pr-check.yml` when the
+`stub-impl` label is present.
+
+Suggested checklist:
+
+- `web_search` for `"<ClassOrStruct> 5.7"` and `"<HeaderName> 5.7"`.
+- Confirm `TryUpdateDefaultConfigFile()` is used wherever `.ini` is persisted.
+- Skim the relevant `Engine/Source/.../Public/*.h` headers in the
+  UE 5.7 install (or the engine GitHub branch) for renamed symbols.
+
+## 3. Branch + scope
+
+```pwsh
+git checkout main
+git pull --ff-only origin main
+git checkout -b codex/stubs-w<N>-<category>-part<M>
+```
+
+Cap each PR at **8 handlers**. If your issue has more, split it; only the
+final PR carries `Closes #<issue>`.
+
+## 4. Implement (C++ side)
+
+Edit only the category's `EpicUnrealMCP<Cat>Commands.cpp` /
+`EpicUnrealMCP<Cat>Commands.h`. Never edit `EpicUnrealMCPRouter.cpp`,
+`EpicUnrealMCPBridge.cpp`, or `scripts\live_e2e_smoke.py` from a
+category PR (see `docs/dev/shared-file-policy.md`).
+
+Skeleton (copy and adapt):
+
+```cpp
+TSharedPtr<FJsonObject> FEpicUnrealMCP<Cat>Commands::Handle<Action>(
+    const TSharedPtr<FJsonObject>& Params)
+{
+    if (!Is<Cat>Available()) return MakeUnavailable(TEXT("<command>"));
+
+#if WITH_<MODULE>_MCP
+    // 1. Validate inputs (return CreateErrorResponse on failure).
+    // 2. Resolve UObjects.
+    // 3. FMCPScopedTransaction Tx(LOCTEXT(...));
+    // 4. Object->Modify();
+    //    perform the real UE 5.7 API call.
+    // 5. If persisting ini, use
+    //    FEpicUnrealMCPCommonUtils::TryUpdateDefaultConfigFileSafe(Object);
+    auto Data = MakeShared<FJsonObject>();
+    Data->SetBoolField(TEXT("executed"), true);
+    Data->SetStringField(TEXT("path"), Object->GetPathName());
+    return MakeSuccessEnvelope(Data);
+#else
+    return MakeUnavailable(TEXT("<command>"));
+#endif
+}
+```
+
+Forbidden:
+
+- `UpdateDefaultConfigFile()` (use the `Try` form).
+- `Data->SetBoolField(TEXT("queued"), true)` on success paths.
+- Adding entries to `EpicUnrealMCPRouter.cpp` (queue in PR body instead).
+
+## 5. Implement (Python side)
+
+Edit only `Python/server/<category>_tools.py`. Validate inputs with
+`pydantic`. Map the new tool name to the C++ command name and add a unit
+test under `Python/tests/unit/test_<category>_<handler>.py`.
+
+Minimum tests per handler:
+
+- happy path
+- invalid input
+- connection / command error
+- `assert_executed(result, "<command>")`
+- `queued: true` is **not** in the response data
+
+## 6. Local validation
+
+```pwsh
+python scripts\audit_route_contracts.py --strict
+python scripts\audit_no_new_queued.py
+cd Python; python -m pytest tests\unit tests\contract -q
+pwsh -File scripts\run_local_uat_buildplugin.ps1
+```
+
+Capture the `artifacts\local_uat\<timestamp>\runuat.log` path and paste
+it into the PR body's `## Tests` section.
+
+## 7. CHANGELOG fragment
+
+Drop one Markdown file at
+`CHANGELOG.d/w<N>-<category>-<slug>.md`. See
+`CHANGELOG.d/README.md` for the shape.
+
+## 8. Open the PR
+
+Use the template. Make sure `## Scope reconciliation`,
+`## UE 5.7 API research`, and `## Tests` are present; the labeler picks
+up the `stub-impl` label automatically when you touch a category `*.cpp`
+file, which in turn triggers the agents-md-pr-check workflow.
+
+## 9. After merge
+
+Comment on the parent issue with:
+
+- handlers promoted
+- residual queued sites (link to commit/lines)
+- next planned PR (if any)
+
+The reviewer/integrator folds your fragment(s) and updates
+`artifacts/queued_baseline.json` during the wave-close PR.

--- a/docs/dev/runbooks/wave-close.md
+++ b/docs/dev/runbooks/wave-close.md
@@ -1,0 +1,67 @@
+# Wave-close PR Runbook
+
+234-stubs Wave 0.5 follow-up (umbrella: #69).
+
+Recipe for the reviewer / integrator who lands the wave-close PR after
+every category in the wave is done.
+
+## 1. Confirm wave readiness
+
+- Every category issue in the wave is closed (or has a final PR open).
+- `python scripts/audit_no_new_queued.py --print` shows the expected
+  per-file drop for the wave.
+- `pytest Python/tests/unit Python/tests/contract` green on main.
+
+## 2. Branch
+
+```pwsh
+git checkout main
+git pull --ff-only origin main
+git checkout -b codex/wave<N>-close
+```
+
+## 3. Fold CHANGELOG fragments
+
+```pwsh
+python scripts/fold_changelog_fragments.py --wave <N>
+```
+
+Commits should be:
+
+1. `chore(changelog): fold wave <N> fragments`
+2. `chore(audit): lower queued baseline after wave <N>`
+3. `feat(shared): apply queued router / live-smoke edits collected during wave <N>`
+
+The third commit applies any *Router / Bridge / live_e2e_smoke notes*
+queued in the category PR bodies. Audit each insertion against
+`docs/dev/shared-file-policy.md`.
+
+## 4. Lower the queued baseline
+
+```pwsh
+python scripts/audit_no_new_queued.py --update-baseline
+git add artifacts/queued_baseline.json
+git commit -m "chore(audit): lower queued baseline after wave <N>"
+```
+
+## 5. Run the wave smoke
+
+```pwsh
+python scripts/live_e2e_smoke.py --group wave<N>
+```
+
+Copy the report path into the wave roadmap issue's Done comment.
+
+## 6. Roadmap issue close
+
+Close `#78 / #83 / #88 / #93 / #98` with a Done comment that lists:
+
+- merged PRs
+- handler count promoted
+- residual queued sites (if any) + follow-up issue links
+- live smoke result path
+
+## 7. Umbrella update (#69)
+
+Edit the umbrella issue's body table to tick the wave. Do not close
+#69 until W5 is done.

--- a/docs/dev/runbooks/wave-close.md
+++ b/docs/dev/runbooks/wave-close.md
@@ -65,3 +65,42 @@ Close `#78 / #83 / #88 / #93 / #98` with a Done comment that lists:
 
 Edit the umbrella issue's body table to tick the wave. Do not close
 #69 until W5 is done.
+
+## 8. Sanity checks for label / CI recovery
+
+If the labeler workflow did not run on the PR (e.g. GitHub Actions queue
+delays), kick it manually after merging the wave-close PR:
+
+```pwsh
+gh workflow run "PR labeler (234-stubs)"
+gh workflow run "AGENTS.md PR body check (234-stubs)" -f pr_number=<PR>
+gh workflow run "queued:true regression audit (234-stubs)"
+```
+
+If the `ue5.7-build` label disappears from the repo settings, recreate
+it (it gates the self-hosted UE 5.7 RunUAT BuildPlugin job):
+
+```pwsh
+gh api -X POST 'repos/{owner}/{repo}/labels' `
+  -f name='ue5.7-build' `
+  -f color='1D76DB' `
+  -f description='Trigger the self-hosted UE 5.7 RunUAT BuildPlugin job'
+```
+
+## 9. Umbrella (#69) close (W5 only)
+
+After W5 is merged and `python scripts/audit_no_new_queued.py --print`
+reports the expected residual count (zero, or only handlers split out
+into follow-up issues), open `codex-umbrella-close-69`:
+
+```pwsh
+python scripts/fold_changelog_fragments.py --all-waves
+python scripts/audit_no_new_queued.py --update-baseline
+```
+
+Close #69 with a comment that:
+
+- links every wave roadmap close PR (#78, #83, #88, #93, #98)
+- summarises promoted handler totals
+- enumerates the follow-up issues created for residual shallow real-impl
+  polish (the 41 handlers outside the 234 headline)

--- a/docs/dev/shared-file-policy.md
+++ b/docs/dev/shared-file-policy.md
@@ -1,0 +1,55 @@
+# Shared-file policy (234-stubs Waves 1-5)
+
+234-stubs Wave 0.5 follow-up (umbrella: #69).
+
+Wave 1-5 work involves up to 4 category PRs landing per week. To keep
+merges friction-free we mark a small set of files as "shared":
+**category PRs must not edit them.** The reviewer/integrator folds in
+changes via a daily merge PR or the per-wave close PR.
+
+## Shared files (do not edit from a category PR)
+
+| File | Why it is shared |
+|---|---|
+| `Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPRouter.cpp` | Single TMap with 700+ entries; any addition collides with every other category PR. |
+| `Plugins/UnrealMCP/Source/UnrealMCP/Private/EpicUnrealMCPBridge.cpp` | Owns the handler-class registry; every new `*Commands` class touches it. |
+| `scripts/live_e2e_smoke.py` | Single `WAVE_GROUPS` dict + `CASES` list shared by every wave. |
+| `CHANGELOG.md` | 100+ KiB file; serializing PRs through it is slow. Use `CHANGELOG.d/` fragments. |
+| `artifacts/queued_baseline.json` | Lowered only by wave-close PRs (via `scripts/audit_no_new_queued.py --update-baseline`). |
+
+## How category PRs land changes that would touch a shared file
+
+1. **Router.cpp / Bridge.cpp**
+   - Add the new handler under the *existing* `F<Cat>Commands` class. The
+     router already maps the command name to a numeric bucket; if a brand-new
+     command is introduced, add it to the PR description's *Router entries*
+     section and leave the actual edit to the reviewer/integrator.
+
+2. **live_e2e_smoke.py**
+   - Add the new `case_<name>` function in a small standalone file under
+     `scripts/live_e2e_smoke_cases/<wave>_<category>.py` (created on demand)
+     and import it from the runner via the next wave-close PR. Smoke cases
+     that block a single PR's verification can be run locally with
+     `python scripts/live_e2e_smoke.py --only <case>` (the reviewer wires
+     it into the dispatch dict at fold-in time).
+
+3. **CHANGELOG.md**
+   - Always drop a fragment in `CHANGELOG.d/` (see that directory's
+     `README.md`).
+
+4. **artifacts/queued_baseline.json**
+   - Never lower from a category PR. `scripts/audit_no_new_queued.py` will
+     refuse to merge such a PR with a regression. The wave-close PR is the
+     only place that runs `--update-baseline`.
+
+## Conflict resolution
+
+If two category PRs land within minutes of each other and rebase noise
+appears on a shared file, **stop merging** and let the
+reviewer/integrator land a rebase commit first. Do **not** force-push a
+category branch with shared-file edits to "fix" the conflict.
+
+## Categories and owners
+
+See `docs/implementation-plan-234-stubs.md` for the per-wave / per-category
+ownership table.

--- a/docs/implementation-plan-234-stubs.md
+++ b/docs/implementation-plan-234-stubs.md
@@ -313,3 +313,36 @@ Movie Render Queue and extend M8 / M9 / M10 due dates accordingly.
 
 A spike doc lives under `docs/spike/<category>-ue57.md` for each of
 these before the implementation PRs land.
+
+## 18. W0.5 refinements applied on top of #105
+
+These tightenings landed on the same `codex-w0-followup-issue-resolution-infra`
+branch as the original #105 commits, addressing review findings:
+
+- **`agents-md-pr-check.yml` now always runs.** The previous job-level
+  `if: contains(github.event.pull_request.labels.*.name, 'stub-impl')`
+  caused the check to be reported as *skipped*, which GitHub branch
+  protection treats as "no status reported" and therefore cannot be
+  required. The `stub-impl` guard is now evaluated inside the script
+  body via `actions/github-script@v7`, so the check is always present
+  on every PR and can be marked Required.
+- **`ue5.7-build` repository label created.** Without it, the gated
+  `RunUAT BuildPlugin` job in `ue57-build.yml` could never trigger
+  (and `actions/labeler@v5` would fail on first run trying to apply a
+  non-existent label). Colour `#1D76DB`, description "Trigger the
+  self-hosted UE 5.7 RunUAT BuildPlugin job in ue57-build.yml".
+- **`concurrency`/`workflow_dispatch` added to all three new
+  workflows** (`labeler.yml`, `agents-md-pr-check.yml`,
+  `queued-audit.yml`). The concurrency groups prevent stale runs from
+  blocking re-pushes; the dispatch trigger gives the reviewer a manual
+  recovery path when the GitHub Actions queue is backed up (this was
+  the situation observed on the original #105 push, where no run was
+  scheduled within 15 minutes).
+- **`scripts/fold_changelog_fragments.py --all-waves`** drives the
+  umbrella-close PR (#69 close) without five separate invocations.
+- **`Python/tests/unit/test_w0_followup_workflow_hardening.py`** locks
+  the above invariants in place so a future PR cannot silently revert
+  them (the test fails if the job-level skip returns, the concurrency
+  block disappears, or the labeler config drops a category).
+- **`docs/dev/runbooks/wave-close.md` §§8-9** documents the manual
+  `gh workflow run` recovery commands and the umbrella-close steps.

--- a/docs/implementation-plan-234-stubs.md
+++ b/docs/implementation-plan-234-stubs.md
@@ -205,3 +205,111 @@ These pieces live in the bridge and unblock every later wave:
 - [ ] `docs/implementation-plan-234-stubs.md` updated only if the plan
       itself changed (do **not** update it just to tick items — those go in
       the wave / category issue checklists).
+
+## 13. Wave 0.5 follow-up infrastructure (delivered separately from #76)
+
+The follow-up PR `codex/w0-followup-issue-resolution-infra` adds the
+collision-avoidance and audit machinery that makes Waves 1-5
+parallelisable across multiple worker agents. None of these files were
+in scope for Wave 0 itself, but every Wave 1+ PR depends on them.
+
+- `scripts/audit_no_new_queued.py` + `artifacts/queued_baseline.json`
+  Promotes the legacy warn-only `queued: true` grep to a blocking
+  audit. Run by `.github/workflows/queued-audit.yml`. Baseline is only
+  lowered from a wave-close PR via `--update-baseline`.
+- `scripts/run_local_uat_buildplugin.ps1`
+  One-liner wrapper for `RunUAT BuildPlugin` that captures the log under
+  `artifacts/local_uat/<timestamp>/runuat.log` so PR authors can quote a
+  deterministic path in the PR description.
+- `scripts/fold_changelog_fragments.py` + `CHANGELOG.d/`
+  Lets every category PR drop a fragment instead of editing the
+  100+ KiB `CHANGELOG.md` directly. The wave-close PR folds them into
+  `## [Unreleased]` and removes the originals.
+- `.github/labeler.yml` + `.github/workflows/labeler.yml`
+  Apply `ue5.7-build`, `stub-impl`, and `stub-cat-<key>` automatically
+  based on changed paths. `ue5.7-build` is required to trigger the
+  self-hosted `RunUAT BuildPlugin` job in `ue57-build.yml`.
+- `.github/workflows/agents-md-pr-check.yml`
+  Fails the PR if the body of a `stub-impl` PR is missing
+  `## Scope reconciliation`, `## UE 5.7 API research`, or `## Tests`.
+  Mirrors the AGENTS.md mandate so reviewers do not have to enforce it
+  manually.
+- `.github/PULL_REQUEST_TEMPLATE.md`
+  Canonical template that satisfies the agents-md check by default and
+  records the data the reviewer needs to integrate the change without
+  follow-up questions.
+- `docs/dev/shared-file-policy.md`
+  Single source of truth for "do not touch these files in a category
+  PR". Category workers must read this before writing any C++.
+- `docs/dev/runbooks/issue-resolution.md`
+  Step-by-step recipe a worker can follow from issue selection to PR
+  merge.
+- `docs/dev/runbooks/wave-close.md`
+  Step-by-step recipe the reviewer follows to drain `CHANGELOG.d/`,
+  lower the queued baseline, and close the wave roadmap issue.
+
+## 14. Updated PR / branch policy (supersedes #76 7.5)
+
+- Branch: `codex/stubs-w<N>-<category>-part<M>`.
+- Maximum 8 handlers per PR; large categories (>8) split into `part1`,
+  `part2`, ...
+- Final part PR uses `Closes #<issue>`; intermediate parts use
+  `Refs #<issue>`.
+- Shared files (router, bridge, `scripts/live_e2e_smoke.py`,
+  `CHANGELOG.md`, queued baseline) are *queued in the PR description*
+  and applied by the wave-close PR. See
+  `docs/dev/shared-file-policy.md`.
+- Every `stub-impl` PR must include `## Scope reconciliation`,
+  `## UE 5.7 API research`, and `## Tests` sections (the
+  agents-md-pr-check workflow enforces this).
+- Before opening the PR, run:
+
+  ```pwsh
+  python scripts\audit_route_contracts.py --strict
+  python scripts\audit_no_new_queued.py
+  cd Python; python -m pytest tests\unit tests\contract -q
+  pwsh -File scripts\run_local_uat_buildplugin.ps1
+  ```
+
+  and quote the artifact paths in the PR body.
+
+## 15. Wave -> milestone schedule
+
+| Phase | Issues | Target due |
+|---|---|---|
+| W0.5 | infra (this section) | 2026-05-27 |
+| W1 (#78) | #79, #80 | 2026-06-07 |
+| W2 (#83) | #84, #85, #86, #87 | 2026-07-04 |
+| W3 (#88) | #89, #90, #91, #92 | 2026-07-18 |
+| W4 (#93) | #94, #95, #96, #97 | 2026-08-01 |
+| W5 (#98) | #99, #100, #101 | 2026-08-08 |
+| Umbrella (#69) | close after W5 | 2026-08-08 + 2 days |
+
+## 16. Resource allocation
+
+- Worker A (light categories): Landscape, DataTable, Water, Localization,
+  MetaSound.
+- Worker B (editor / asset categories): Animation Rigging, Sequencer,
+  Foliage, Source Control, Testing/Validation.
+- Worker C (gameplay / physics categories): GAS, Chaos, Movie Render
+  Queue, Mobile/XR.
+- Worker D (high-risk-API categories): AI/Nav Extension, PCG, Networking.
+- Reviewer/Integrator: owns W0.5, shared-file edits, wave-close PRs,
+  CHANGELOG fold-in, queued baseline lowering, and #69.
+
+With only two workers available, serialise PCG / Chaos / Networking /
+Movie Render Queue and extend M8 / M9 / M10 due dates accordingly.
+
+## 17. SME review recommendations
+
+| Category | Reason |
+|---|---|
+| #84 AI/Nav Extension | StateTree + Navigation + AI Sense API churn in 5.7. |
+| #89 Chaos | GeometryCollection / Cluster API churn in 5.7. |
+| #91 PCG | PCG graph + GeometryScript interop is new in 5.7. |
+| #95 Movie Render Queue | MovieGraph supersedes MRQ in 5.7. |
+| #96 Networking | Iris + ReplicationGraph layout changes. |
+| #99 MetaSound | MetaSoundFrontend reorg in 5.7. |
+
+A spike doc lives under `docs/spike/<category>-ue57.md` for each of
+these before the implementation PRs land.

--- a/docs/spike/ai-nav-ue57.md
+++ b/docs/spike/ai-nav-ue57.md
@@ -1,0 +1,45 @@
+# AI / Navigation Extension spike
+
+234-stubs spike doc (placeholder).
+
+Owner: <fill in when starting the spike>
+Wave: W2
+Issue: #84
+Status: TODO
+
+## Goal
+
+Establish the smallest possible working surface against UE 5.7 for this
+category before the implementation PRs begin. The spike must produce:
+
+- A short paragraph per high-risk API describing the 5.7 shape and any
+  rename / removal vs 5.3.
+- At least one promoted handler that returns `executed: true` in the
+  live editor, plus the matching unit test.
+- A list of headers / classes that the rest of the category PRs should
+  prefer (so workers don't re-derive them).
+
+## Required pre-impl research
+
+> AGENTS.md mandates that every handler in this category includes a
+> `## UE 5.7 API research` block in its PR. Capture the canonical
+> search terms and findings here so subsequent PRs can link back.
+
+- `web_search` `"<class or struct> 5.7"`
+- `web_search` `"<header name> 5.7"`
+- GitHub source (auth required): https://github.com/EpicGames/UnrealEngine
+- Public docs: https://docs.unrealengine.com/5.7/
+
+## Findings
+
+_TBD by spike owner._
+
+## Reference implementation
+
+_TBD by spike owner. Add a link to the PR that promotes the first 1-3
+handlers as the canonical sample._
+
+## Risks
+
+_TBD by spike owner. List anything that would inflate the per-PR
+handler budget below 8._

--- a/docs/spike/chaos-ue57.md
+++ b/docs/spike/chaos-ue57.md
@@ -1,0 +1,45 @@
+# Chaos Physics spike
+
+234-stubs spike doc (placeholder).
+
+Owner: <fill in when starting the spike>
+Wave: W3
+Issue: #89
+Status: TODO
+
+## Goal
+
+Establish the smallest possible working surface against UE 5.7 for this
+category before the implementation PRs begin. The spike must produce:
+
+- A short paragraph per high-risk API describing the 5.7 shape and any
+  rename / removal vs 5.3.
+- At least one promoted handler that returns `executed: true` in the
+  live editor, plus the matching unit test.
+- A list of headers / classes that the rest of the category PRs should
+  prefer (so workers don't re-derive them).
+
+## Required pre-impl research
+
+> AGENTS.md mandates that every handler in this category includes a
+> `## UE 5.7 API research` block in its PR. Capture the canonical
+> search terms and findings here so subsequent PRs can link back.
+
+- `web_search` `"<class or struct> 5.7"`
+- `web_search` `"<header name> 5.7"`
+- GitHub source (auth required): https://github.com/EpicGames/UnrealEngine
+- Public docs: https://docs.unrealengine.com/5.7/
+
+## Findings
+
+_TBD by spike owner._
+
+## Reference implementation
+
+_TBD by spike owner. Add a link to the PR that promotes the first 1-3
+handlers as the canonical sample._
+
+## Risks
+
+_TBD by spike owner. List anything that would inflate the per-PR
+handler budget below 8._

--- a/docs/spike/metasound-ue57.md
+++ b/docs/spike/metasound-ue57.md
@@ -1,0 +1,45 @@
+# MetaSound spike
+
+234-stubs spike doc (placeholder).
+
+Owner: <fill in when starting the spike>
+Wave: W5
+Issue: #99
+Status: TODO
+
+## Goal
+
+Establish the smallest possible working surface against UE 5.7 for this
+category before the implementation PRs begin. The spike must produce:
+
+- A short paragraph per high-risk API describing the 5.7 shape and any
+  rename / removal vs 5.3.
+- At least one promoted handler that returns `executed: true` in the
+  live editor, plus the matching unit test.
+- A list of headers / classes that the rest of the category PRs should
+  prefer (so workers don't re-derive them).
+
+## Required pre-impl research
+
+> AGENTS.md mandates that every handler in this category includes a
+> `## UE 5.7 API research` block in its PR. Capture the canonical
+> search terms and findings here so subsequent PRs can link back.
+
+- `web_search` `"<class or struct> 5.7"`
+- `web_search` `"<header name> 5.7"`
+- GitHub source (auth required): https://github.com/EpicGames/UnrealEngine
+- Public docs: https://docs.unrealengine.com/5.7/
+
+## Findings
+
+_TBD by spike owner._
+
+## Reference implementation
+
+_TBD by spike owner. Add a link to the PR that promotes the first 1-3
+handlers as the canonical sample._
+
+## Risks
+
+_TBD by spike owner. List anything that would inflate the per-PR
+handler budget below 8._

--- a/docs/spike/movie-render-queue-ue57.md
+++ b/docs/spike/movie-render-queue-ue57.md
@@ -1,0 +1,45 @@
+# Movie Render Queue + Movie Graph spike
+
+234-stubs spike doc (placeholder).
+
+Owner: <fill in when starting the spike>
+Wave: W4
+Issue: #95
+Status: TODO
+
+## Goal
+
+Establish the smallest possible working surface against UE 5.7 for this
+category before the implementation PRs begin. The spike must produce:
+
+- A short paragraph per high-risk API describing the 5.7 shape and any
+  rename / removal vs 5.3.
+- At least one promoted handler that returns `executed: true` in the
+  live editor, plus the matching unit test.
+- A list of headers / classes that the rest of the category PRs should
+  prefer (so workers don't re-derive them).
+
+## Required pre-impl research
+
+> AGENTS.md mandates that every handler in this category includes a
+> `## UE 5.7 API research` block in its PR. Capture the canonical
+> search terms and findings here so subsequent PRs can link back.
+
+- `web_search` `"<class or struct> 5.7"`
+- `web_search` `"<header name> 5.7"`
+- GitHub source (auth required): https://github.com/EpicGames/UnrealEngine
+- Public docs: https://docs.unrealengine.com/5.7/
+
+## Findings
+
+_TBD by spike owner._
+
+## Reference implementation
+
+_TBD by spike owner. Add a link to the PR that promotes the first 1-3
+handlers as the canonical sample._
+
+## Risks
+
+_TBD by spike owner. List anything that would inflate the per-PR
+handler budget below 8._

--- a/docs/spike/networking-iris-ue57.md
+++ b/docs/spike/networking-iris-ue57.md
@@ -1,0 +1,45 @@
+# Networking + Iris spike
+
+234-stubs spike doc (placeholder).
+
+Owner: <fill in when starting the spike>
+Wave: W4
+Issue: #96
+Status: TODO
+
+## Goal
+
+Establish the smallest possible working surface against UE 5.7 for this
+category before the implementation PRs begin. The spike must produce:
+
+- A short paragraph per high-risk API describing the 5.7 shape and any
+  rename / removal vs 5.3.
+- At least one promoted handler that returns `executed: true` in the
+  live editor, plus the matching unit test.
+- A list of headers / classes that the rest of the category PRs should
+  prefer (so workers don't re-derive them).
+
+## Required pre-impl research
+
+> AGENTS.md mandates that every handler in this category includes a
+> `## UE 5.7 API research` block in its PR. Capture the canonical
+> search terms and findings here so subsequent PRs can link back.
+
+- `web_search` `"<class or struct> 5.7"`
+- `web_search` `"<header name> 5.7"`
+- GitHub source (auth required): https://github.com/EpicGames/UnrealEngine
+- Public docs: https://docs.unrealengine.com/5.7/
+
+## Findings
+
+_TBD by spike owner._
+
+## Reference implementation
+
+_TBD by spike owner. Add a link to the PR that promotes the first 1-3
+handlers as the canonical sample._
+
+## Risks
+
+_TBD by spike owner. List anything that would inflate the per-PR
+handler budget below 8._

--- a/docs/spike/pcg-ue57.md
+++ b/docs/spike/pcg-ue57.md
@@ -1,0 +1,45 @@
+# PCG (Procedural Content Generation) spike
+
+234-stubs spike doc (placeholder).
+
+Owner: <fill in when starting the spike>
+Wave: W3
+Issue: #91
+Status: TODO
+
+## Goal
+
+Establish the smallest possible working surface against UE 5.7 for this
+category before the implementation PRs begin. The spike must produce:
+
+- A short paragraph per high-risk API describing the 5.7 shape and any
+  rename / removal vs 5.3.
+- At least one promoted handler that returns `executed: true` in the
+  live editor, plus the matching unit test.
+- A list of headers / classes that the rest of the category PRs should
+  prefer (so workers don't re-derive them).
+
+## Required pre-impl research
+
+> AGENTS.md mandates that every handler in this category includes a
+> `## UE 5.7 API research` block in its PR. Capture the canonical
+> search terms and findings here so subsequent PRs can link back.
+
+- `web_search` `"<class or struct> 5.7"`
+- `web_search` `"<header name> 5.7"`
+- GitHub source (auth required): https://github.com/EpicGames/UnrealEngine
+- Public docs: https://docs.unrealengine.com/5.7/
+
+## Findings
+
+_TBD by spike owner._
+
+## Reference implementation
+
+_TBD by spike owner. Add a link to the PR that promotes the first 1-3
+handlers as the canonical sample._
+
+## Risks
+
+_TBD by spike owner. List anything that would inflate the per-PR
+handler budget below 8._

--- a/scripts/audit_no_new_queued.py
+++ b/scripts/audit_no_new_queued.py
@@ -1,0 +1,217 @@
+"""Audit that no new `queued: true` success path is introduced.
+
+234-stubs Wave 0.5 follow-up (umbrella: #69).
+
+This script counts every `SetBoolField(TEXT("queued"), true)` occurrence in
+the C++ command handlers under
+`Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/*Commands.cpp` and
+compares them to a baseline JSON snapshot stored at
+`artifacts/queued_baseline.json`.
+
+The audit *does not* require existing queued sites to be removed (that is the
+job of the per-category Wave 1-5 PRs), but it does fail if a PR adds new
+queued sites or moves them between files in a way that increases the total.
+
+Usage:
+    # Verify against the existing baseline.
+    python scripts/audit_no_new_queued.py
+
+    # Rebuild the baseline (only after a wave close PR).
+    python scripts/audit_no_new_queued.py --update-baseline
+
+    # Use a custom baseline location (CI artifacts).
+    python scripts/audit_no_new_queued.py --baseline path/to/queued_baseline.json
+
+Exit codes:
+    0  Current counts are equal to or lower than baseline (and per-file is
+       not strictly larger anywhere).
+    1  A regression was detected (count increased for the repository or for a
+       specific file). The CI workflow uses this exit code to block the PR.
+    2  Invalid arguments or unreadable baseline file.
+
+The baseline schema is intentionally tiny so that diffs in PRs are obvious:
+
+    {
+        "schema": 1,
+        "generated_utc": "2026-05-23T00:00:00Z",
+        "total": 226,
+        "per_file": {
+            "EpicUnrealMCPAiNavExtensionCommands.cpp": 23,
+            ...
+        }
+    }
+
+When the baseline is rebuilt the previous values are replaced atomically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CPP_DIR = (
+    REPO_ROOT
+    / "Plugins"
+    / "UnrealMCP"
+    / "Source"
+    / "UnrealMCP"
+    / "Private"
+    / "Commands"
+)
+DEFAULT_BASELINE = REPO_ROOT / "artifacts" / "queued_baseline.json"
+
+# Matches the canonical queued-success pattern used by every stub category
+# handler: `Data->SetBoolField(TEXT("queued"), true);`.
+QUEUED_PATTERN = re.compile(
+    r'SetBoolField\(\s*TEXT\(\s*"queued"\s*\)\s*,\s*true\s*\)'
+)
+
+
+def _iter_cpp_files() -> Iterable[Path]:
+    if not CPP_DIR.is_dir():
+        return []
+    return sorted(CPP_DIR.glob("*Commands.cpp"))
+
+
+def count_queued_per_file() -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for path in _iter_cpp_files():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        n = len(QUEUED_PATTERN.findall(text))
+        if n:
+            counts[path.name] = n
+    return counts
+
+
+def load_baseline(baseline_path: Path) -> Dict[str, object]:
+    if not baseline_path.is_file():
+        raise SystemExit(
+            f"baseline file is missing: {baseline_path}. Run with "
+            "--update-baseline once to seed it."
+        )
+    try:
+        data = json.loads(baseline_path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError) as exc:  # pragma: no cover
+        raise SystemExit(f"failed to read baseline {baseline_path}: {exc}") from exc
+    if not isinstance(data, dict) or "per_file" not in data:
+        raise SystemExit(
+            f"baseline {baseline_path} is malformed (missing 'per_file')."
+        )
+    return data
+
+
+def write_baseline(baseline_path: Path, counts: Dict[str, int]) -> None:
+    payload = {
+        "schema": 1,
+        "generated_utc": _dt.datetime.now(_dt.timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        ),
+        "total": sum(counts.values()),
+        "per_file": dict(sorted(counts.items())),
+    }
+    baseline_path.parent.mkdir(parents=True, exist_ok=True)
+    baseline_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def diff_against_baseline(
+    current: Dict[str, int], baseline: Dict[str, object]
+) -> List[str]:
+    """Return a list of human-readable regression messages.
+
+    A regression is reported when:
+      * the total across all files strictly increased, OR
+      * any individual file's count strictly increased, OR
+      * a brand-new file appeared with a non-zero count.
+    """
+    problems: List[str] = []
+    baseline_per_file = baseline.get("per_file") or {}
+    if not isinstance(baseline_per_file, dict):
+        problems.append("baseline 'per_file' is not an object")
+        return problems
+
+    baseline_total = int(baseline.get("total") or 0)
+    current_total = sum(current.values())
+    if current_total > baseline_total:
+        problems.append(
+            f"total queued:true regressed: baseline={baseline_total} -> "
+            f"current={current_total} (delta=+{current_total - baseline_total})"
+        )
+
+    for name, current_count in sorted(current.items()):
+        prior = int(baseline_per_file.get(name, 0))
+        if current_count > prior:
+            problems.append(
+                f"{name}: {prior} -> {current_count} (+{current_count - prior})"
+            )
+    return problems
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=DEFAULT_BASELINE,
+        help=f"baseline JSON path (default: {DEFAULT_BASELINE.relative_to(REPO_ROOT)})",
+    )
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="rewrite the baseline file with the current counts and exit 0.",
+    )
+    parser.add_argument(
+        "--print",
+        action="store_true",
+        dest="print_counts",
+        help="print the current per-file counts as JSON on stdout.",
+    )
+    args = parser.parse_args(argv)
+
+    current = count_queued_per_file()
+
+    if args.print_counts:
+        print(json.dumps({"total": sum(current.values()), "per_file": current}, indent=2))
+
+    if args.update_baseline:
+        write_baseline(args.baseline, current)
+        print(
+            f"wrote baseline {args.baseline} "
+            f"(total={sum(current.values())}, files={len(current)})"
+        )
+        return 0
+
+    baseline = load_baseline(args.baseline)
+    problems = diff_against_baseline(current, baseline)
+    if problems:
+        print("queued:true regression detected:")
+        for line in problems:
+            print(f"  - {line}")
+        print(
+            "\nIf this PR intentionally promotes handlers, run "
+            "'python scripts/audit_no_new_queued.py --update-baseline' "
+            "from a wave-close PR (not a category PR) and commit the diff."
+        )
+        return 1
+
+    print(
+        f"queued:true audit OK (current total={sum(current.values())}, "
+        f"baseline total={int(baseline.get('total') or 0)})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/fold_changelog_fragments.py
+++ b/scripts/fold_changelog_fragments.py
@@ -1,0 +1,122 @@
+"""Fold CHANGELOG.d/<wave>-*.md fragments into the top of CHANGELOG.md.
+
+234-stubs Wave 0.5 follow-up (umbrella: #69).
+
+The wave-close PR runs this script to append every accumulated fragment to
+the `## [Unreleased]` section of `CHANGELOG.md` under a new
+`### 234-stubs Wave <n>` subsection. The fragments are then deleted in
+the same commit, leaving `CHANGELOG.d/` ready for the next wave.
+
+Usage:
+    python scripts/fold_changelog_fragments.py --wave 1
+    python scripts/fold_changelog_fragments.py --wave 3 --dry-run
+
+The script is intentionally idempotent: if the target subsection already
+exists for the wave, fragments are *appended* to it instead of duplicating
+the heading.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import re
+import sys
+from pathlib import Path
+from typing import List
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+FRAGMENT_DIR = REPO_ROOT / "CHANGELOG.d"
+
+UNRELEASED_HEADER = "## [Unreleased]"
+WAVE_HEADING_FMT = "### 234-stubs Wave {wave}"
+EXCLUDED_FRAGMENT_NAMES = {"README.md", ".gitkeep"}
+
+
+def _iter_fragments(wave: int) -> List[Path]:
+    if not FRAGMENT_DIR.is_dir():
+        return []
+    prefix = f"w{wave}-"
+    out: List[Path] = []
+    for p in sorted(FRAGMENT_DIR.glob("*.md")):
+        if p.name in EXCLUDED_FRAGMENT_NAMES:
+            continue
+        if not p.name.lower().startswith(prefix):
+            continue
+        out.append(p)
+    return out
+
+
+def _ensure_unreleased(content: str) -> str:
+    if UNRELEASED_HEADER in content:
+        return content
+    today = _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%d")
+    header = f"{UNRELEASED_HEADER}\n\n_Last folded: {today}_\n\n"
+    return header + content
+
+
+def _splice_wave_block(content: str, wave: int, body: str) -> str:
+    """Insert or extend the wave subsection inside ## [Unreleased]."""
+    wave_heading = WAVE_HEADING_FMT.format(wave=wave)
+    if wave_heading in content:
+        pattern = re.compile(
+            r"(" + re.escape(wave_heading) + r"\s*\n)",
+            re.MULTILINE,
+        )
+        return pattern.sub(r"\1\n" + body.strip() + "\n\n", content, count=1)
+
+    pattern = re.compile(
+        r"(" + re.escape(UNRELEASED_HEADER) + r"\s*\n)",
+        re.MULTILINE,
+    )
+    section = f"\n{wave_heading}\n\n{body.strip()}\n\n"
+    return pattern.sub(r"\1" + section, content, count=1)
+
+
+def fold(wave: int, *, dry_run: bool = False) -> int:
+    fragments = _iter_fragments(wave)
+    if not fragments:
+        print(f"no fragments found for wave {wave}")
+        return 0
+
+    body_chunks: List[str] = []
+    for fragment in fragments:
+        body_chunks.append(fragment.read_text(encoding="utf-8-sig").strip())
+    body = "\n\n".join(body_chunks)
+
+    original = CHANGELOG.read_text(encoding="utf-8-sig") if CHANGELOG.exists() else ""
+    updated = _ensure_unreleased(original)
+    updated = _splice_wave_block(updated, wave, body)
+
+    if dry_run:
+        print(f"[dry-run] would fold {len(fragments)} fragment(s) into wave {wave}")
+        for fragment in fragments:
+            try:
+                rel = fragment.relative_to(REPO_ROOT)
+            except ValueError:
+                rel = fragment
+            print(f"  - {rel}")
+        return 0
+
+    CHANGELOG.write_text(updated, encoding="utf-8")
+    for fragment in fragments:
+        fragment.unlink()
+    print(
+        f"folded {len(fragments)} fragment(s) into "
+        f"'{WAVE_HEADING_FMT.format(wave=wave)}' under {UNRELEASED_HEADER}"
+    )
+    return 0
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--wave", type=int, required=True, choices=[1, 2, 3, 4, 5])
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+    return fold(args.wave, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/fold_changelog_fragments.py
+++ b/scripts/fold_changelog_fragments.py
@@ -112,9 +112,24 @@ def fold(wave: int, *, dry_run: bool = False) -> int:
 
 def main(argv: List[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--wave", type=int, required=True, choices=[1, 2, 3, 4, 5])
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--wave", type=int, choices=[1, 2, 3, 4, 5])
+    group.add_argument(
+        "--all-waves",
+        action="store_true",
+        help=(
+            "fold every wave (W1..W5) in order. Used by the umbrella-close "
+            "PR after #69 is ready to ship."
+        ),
+    )
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args(argv)
+
+    if args.all_waves:
+        rc = 0
+        for wave in (1, 2, 3, 4, 5):
+            rc = fold(wave, dry_run=args.dry_run) or rc
+        return rc
     return fold(args.wave, dry_run=args.dry_run)
 
 

--- a/scripts/run_local_uat_buildplugin.ps1
+++ b/scripts/run_local_uat_buildplugin.ps1
@@ -1,0 +1,112 @@
+<#
+.SYNOPSIS
+    Runs UE 5.7 RunUAT BuildPlugin against this repo's UnrealMCP plugin.
+
+.DESCRIPTION
+    234-stubs Wave 0.5 follow-up (umbrella: #69).
+
+    Wraps RunUAT.bat BuildPlugin so every category PR can attach the same
+    locally-produced log without re-deriving the command line. Sets up the
+    output directory, captures both stdout and stderr to a timestamped log
+    under `artifacts/local_uat/`, and prints a short summary at the end
+    so the artifact path can be quoted in the PR description.
+
+    Honours these inputs (in order of precedence):
+        1. -UnrealEngineDir   (CLI arg)
+        2. $env:UNREAL_ENGINE_57_DIR
+        3. $env:UE_5_7_INSTALL_DIR
+        4. C:\Program Files\Epic Games\UE_5.7   (default search)
+
+.PARAMETER UnrealEngineDir
+    Path to the UE 5.7 install root. Defaults to the env var above.
+
+.PARAMETER Platforms
+    Target platforms passed to BuildPlugin. Defaults to "Win64".
+
+.PARAMETER OutputDir
+    Directory that receives the packaged plugin. Defaults to
+    `artifacts/local_uat/<timestamp>/UnrealMCP-Plugin`.
+
+.PARAMETER LogPath
+    Optional explicit log path. Defaults to
+    `artifacts/local_uat/<timestamp>/runuat.log`.
+
+.EXAMPLE
+    pwsh -File scripts/run_local_uat_buildplugin.ps1
+    pwsh -File scripts/run_local_uat_buildplugin.ps1 -UnrealEngineDir "D:\UE_5.7"
+#>
+
+[CmdletBinding()]
+param(
+    [string]$UnrealEngineDir,
+    [string]$Platforms = "Win64",
+    [string]$OutputDir,
+    [string]$LogPath
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+
+function Resolve-UnrealEngineDir {
+    param([string]$Explicit)
+    if ($Explicit) { return $Explicit }
+    if ($env:UNREAL_ENGINE_57_DIR) { return $env:UNREAL_ENGINE_57_DIR }
+    if ($env:UE_5_7_INSTALL_DIR) { return $env:UE_5_7_INSTALL_DIR }
+    $default = "C:\Program Files\Epic Games\UE_5.7"
+    if (Test-Path $default) { return $default }
+    throw "Could not locate UE 5.7. Set -UnrealEngineDir or \$env:UNREAL_ENGINE_57_DIR."
+}
+
+$engineDir = Resolve-UnrealEngineDir -Explicit $UnrealEngineDir
+$runUat = Join-Path $engineDir "Engine\Build\BatchFiles\RunUAT.bat"
+if (-not (Test-Path $runUat)) {
+    throw "RunUAT.bat not found under '$engineDir'. Verify the UE 5.7 install."
+}
+
+$pluginFile = Join-Path $repoRoot "Plugins\UnrealMCP\UnrealMCP.uplugin"
+if (-not (Test-Path $pluginFile)) {
+    throw "UnrealMCP.uplugin not found at '$pluginFile'."
+}
+
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$runDir = Join-Path $repoRoot "artifacts\local_uat\$timestamp"
+New-Item -ItemType Directory -Path $runDir -Force | Out-Null
+
+if (-not $OutputDir) {
+    $OutputDir = Join-Path $runDir "UnrealMCP-Plugin"
+}
+if (-not $LogPath) {
+    $LogPath = Join-Path $runDir "runuat.log"
+}
+
+Write-Host "Engine     : $engineDir"
+Write-Host "Plugin     : $pluginFile"
+Write-Host "Platforms  : $Platforms"
+Write-Host "Output dir : $OutputDir"
+Write-Host "Log file   : $LogPath"
+Write-Host ""
+
+$cmdArgs = @(
+    "BuildPlugin",
+    "-Plugin=$pluginFile",
+    "-Package=$OutputDir",
+    "-TargetPlatforms=$Platforms",
+    "-Rocket"
+)
+
+# Tee everything to the log file while still streaming to the console.
+& $runUat @cmdArgs 2>&1 | Tee-Object -FilePath $LogPath
+$uatExit = $LASTEXITCODE
+
+Write-Host ""
+Write-Host "RunUAT BuildPlugin exit code: $uatExit"
+Write-Host "Log saved to               : $LogPath"
+
+if ($uatExit -ne 0) {
+    Write-Error "BuildPlugin failed. See $LogPath for details."
+    exit $uatExit
+}
+
+Write-Host "BuildPlugin succeeded. Attach the following to your PR description:"
+Write-Host "  - $LogPath"
+Write-Host "  - $OutputDir"


### PR DESCRIPTION
Refs #69

## Scope reconciliation

- Issue checklist count: n/a (infra-only PR, no handlers promoted)
- Existing `queued:true` count (this PR before): 226
- Already `executed:true` count: n/a
- Promoted in this PR: 0
- Notes: this is the Wave 0.5 follow-up. It lands the per-PR safety net so the upcoming W1-W5 category PRs can land in parallel without colliding on `EpicUnrealMCPRouter.cpp`, `EpicUnrealMCPBridge.cpp`, `scripts/live_e2e_smoke.py`, or the 100+ KiB `CHANGELOG.md`.

## UE 5.7 API research

- Search terms: n/a (no UE C++ touched in this PR)
- Official docs / headers checked: n/a
- Deprecated APIs avoided: enforced for *future* PRs by the new `agents-md-pr-check` workflow + the PR template (`UpdateDefaultConfigFile()` block + `TryUpdateDefaultConfigFileSafe` reminder)
- Config persistence decision: n/a
- Module gate(s) used: n/a

## Handlers promoted

- [x] none (infra PR)

## Tests

- Unit: `pytest Python/tests/unit -q` → 1145 passed (incl. 3 new tests: `test_audit_no_new_queued.py`, `test_fold_changelog_fragments.py`, `test_w0_followup_artifacts.py`)
- Contract: `pytest Python/tests/contract -q` → 44 passed
- Route audit: `python scripts/audit_route_contracts.py --strict` → exit 0
- Queued audit: `python scripts/audit_no_new_queued.py` → exit 0 (baseline 226)
- Live smoke (not applicable for an infra-only PR)
- Local RunUAT or CI RunUAT: not applicable (no C++ touched)
- Log artifact path: `artifacts/route_contracts.csv` (regenerated locally)

## CHANGELOG

- Fragment: `CHANGELOG.d/w0.5-issue-resolution-infra.md`

## Router / Bridge / live_e2e_smoke notes

- No edits to `EpicUnrealMCPRouter.cpp`, `EpicUnrealMCPBridge.cpp`, or `scripts/live_e2e_smoke.py`.
- New shared-file policy in `docs/dev/shared-file-policy.md` formalises this rule for Waves 1-5.

## Inventory

New scripts:

- `scripts/audit_no_new_queued.py` (with `--print` / `--update-baseline`).
- `scripts/run_local_uat_buildplugin.ps1`.
- `scripts/fold_changelog_fragments.py`.

New CI workflows:

- `.github/workflows/labeler.yml` (path-based labelling driven by `.github/labeler.yml`).
- `.github/workflows/agents-md-pr-check.yml` (`stub-impl` PRs must include the required body headers).
- `.github/workflows/queued-audit.yml` (blocking `queued:true` baseline check).

New templates:

- `.github/PULL_REQUEST_TEMPLATE.md` (matches the AGENTS.md mandate).
- `.github/ISSUE_TEMPLATE/stub_followup.yml` (for residual work split off during a wave).

New docs:

- `docs/dev/shared-file-policy.md`.
- `docs/dev/runbooks/issue-resolution.md`.
- `docs/dev/runbooks/wave-close.md`.
- `docs/dev/runbooks/README.md`.
- `docs/spike/{ai-nav,chaos,pcg,movie-render-queue,networking-iris,metasound}-ue57.md` (placeholders for #84, #89, #91, #95, #96, #99 spikes).
- `docs/implementation-plan-234-stubs.md` sections 13-17 (W0.5 → W5 schedule, ownership, SME review).

Baseline data:

- `artifacts/queued_baseline.json` (frozen at 226; `/artifacts/*` is gitignored except for this one file).

## What this unblocks

- Wave 1 (#79, #80) can begin immediately; each category PR will land in 8-handler slices using the new template and skip the shared files.
- Wave 2-5 follow the same pattern; the reviewer/integrator uses `docs/dev/runbooks/wave-close.md` for each of #78, #83, #88, #93, #98.
- `#69` stays open until W5 closes; remaining shallow real-impl polish (the 41 handlers outside the 234 count) will be split into follow-up issues via `.github/ISSUE_TEMPLATE/stub_followup.yml`.