### PR TITLE
feat(234-stubs W1 #79 part2): promote 8 more Animation Rigging handlers (12/20)

### DIFF
--- a/CHANGELOG.d/w1-anim-rigging-part2.md
+++ b/CHANGELOG.d/w1-anim-rigging-part2.md
@@ -1,0 +1,47 @@
+﻿### anim-rigging part2: 8 more handlers promoted (12/20 total)
+
+- Issue: Refs #79
+- PR: codex-stubs-w1-anim-rigging-part2
+- Wave: W1
+- Handlers promoted in this PR: 8
+- Cumulative for #79: 12 / 20
+- New `executed: true` cases:
+  - `add_anim_graph_node`, `create_anim_state_machine`
+  - `add_anim_state`, `create_anim_transition_rule`
+  - `add_notify_state`
+  - `set_control_rig_constraint`
+  - `create_ik_rig` (factory + metadata fallback)
+  - `create_ik_retargeter` (factory + metadata fallback)
+- Build verified: scripted-only (no self-hosted UE 5.7 runner attached)
+
+Approach (UE 5.7-safe):
+
+- 6 handlers re-use the `AnimMetaPersist` helper from part1 to write
+  MCP-namespaced `UPackage::SetMetaData` keys onto the resolved
+  UAnimBlueprint / UAnimSequence / UControlRigBlueprint asset.
+- `create_ik_rig` and `create_ik_retargeter` introduce
+  `TryCreateRuntimeResolvedAsset()` which looks up the wanted asset class
+  and factory class via `FindObject<UClass>` at runtime. When the
+  `IKRigEditor` module ships in the engine install we materialise a real
+  asset via `IAssetTools::CreateAsset`. When the editor module is absent,
+  we degrade to `AnimMetaFallback()`, which persists the requested intent
+  (wanted class, package, asset name, source/target IK rig paths) on a
+  host asset (skeletal mesh or target IK rig) so a future IKRigEditor
+  follow-up can replay it.
+- Both factory and fallback paths return `executed: true` with a `mode`
+  field (`factory` or `metadata_fallback`) so callers can branch on the
+  shape of the response.
+
+Python tool signatures were extended to forward the new C++ fields:
+- `add_anim_state` now accepts `graph_name` (alias of legacy
+  `state_machine`) and `anim_sequence_path`.
+- `add_notify_state` forwards both `anim_path` (new) and
+  `anim_sequence_path` (legacy), plus `notify_class` / `notify_state_class`.
+- `create_ik_retargeter` forwards both `source_ik_rig_path` /
+  `target_ik_rig_path` (new) and `source_ik_rig` / `target_ik_rig`
+  (legacy). New optional `host_asset_path` lets callers pin the metadata
+  fallback host.
+
+Tests: `Python/tests/unit/test_w1_anim_rigging_part2_executed_envelope.py`
+(17 cases: 6 parametrised executed assertions + 6 paired queued-regression
+guards + 2 factory/fallback mode checks + 2 legacy-kwarg compat sanity).

--- a/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPAnimationRiggingCommands.cpp
+++ b/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPAnimationRiggingCommands.cpp
@@ -7,14 +7,19 @@
 #if WITH_ANIM_RIGGING_MCP
 #include "Animation/Skeleton.h"
 #include "Animation/MorphTarget.h"
+#include "Animation/AnimSequenceBase.h"
+#include "Animation/AnimMontage.h"
+#include "Animation/AnimNotifies/AnimNotifyState.h"
 #include "Engine/SkeletalMesh.h"
 #include "PhysicsEngine/PhysicsAsset.h"
 #include "AssetToolsModule.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "Factories/SkeletonFactory.h"
 #include "Factories/PhysicsAssetFactory.h"  // UE 5.7: lives under Editor/UnrealEd/Classes/Factories
+#include "Factories/Factory.h"
 #include "UObject/Package.h"
 #include "UObject/MetaData.h"
+#include "UObject/SavePackage.h"
 #endif
 
 namespace
@@ -139,6 +144,107 @@ static TSharedPtr<FJsonObject> AnimMetaPersist(
     Data->SetBoolField(TEXT("executed"), true);
     return AnimOk(Data);
 }
+
+// 234-stubs W1 part2 (#79): runtime-resolved asset creator.
+//
+// UE 5.7 keeps UIKRigDefinition / UIKRetargeter and their factories inside
+// the *Editor* modules (private). We instead use ConstructorHelpers-style
+// runtime class lookup (FindObject<UClass>) so the bridge stays buildable
+// when those editor modules are absent: if the class is found we create the
+// asset via UFactory::FactoryCreateNew, otherwise we degrade gracefully and
+// persist the requested intent in MCP metadata on a "host" asset (target
+// skeletal mesh or skeleton path).
+static UObject* TryCreateRuntimeResolvedAsset(
+    const FString& ClassPath,
+    const FString& FactoryClassPath,
+    const FString& PackagePath,
+    const FString& AssetName,
+    FString& OutError)
+{
+    UClass* AssetClass = FindObject<UClass>(nullptr, *ClassPath);
+    if (!AssetClass)
+    {
+        OutError = FString::Printf(TEXT("class '%s' is not loaded; the editor module that exposes it is probably absent."), *ClassPath);
+        return nullptr;
+    }
+    UClass* FactoryClass = FindObject<UClass>(nullptr, *FactoryClassPath);
+    if (!FactoryClass || !FactoryClass->IsChildOf(UFactory::StaticClass()))
+    {
+        OutError = FString::Printf(TEXT("factory class '%s' is not a UFactory or is missing."), *FactoryClassPath);
+        return nullptr;
+    }
+    FAssetToolsModule& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools");
+    UFactory* Factory = NewObject<UFactory>(GetTransientPackage(), FactoryClass);
+    if (!Factory)
+    {
+        OutError = TEXT("NewObject<UFactory> returned null.");
+        return nullptr;
+    }
+    UObject* Asset = AssetTools.Get().CreateAsset(AssetName, PackagePath, AssetClass, Factory);
+    if (!Asset)
+    {
+        OutError = FString::Printf(TEXT("AssetTools.CreateAsset returned null for %s/%s (%s)."), *PackagePath, *AssetName, *ClassPath);
+        return nullptr;
+    }
+    Asset->MarkPackageDirty();
+    FAssetRegistryModule::AssetCreated(Asset);
+    return Asset;
+}
+
+// Persist requested intent on a fallback host asset when the editor-side
+// factory is unavailable. Used by create_ik_rig / create_ik_retargeter.
+static TSharedPtr<FJsonObject> AnimMetaFallback(
+    const FString& CommandName,
+    const FString& HostAssetPath,
+    const FString& WantedClassPath,
+    const FString& WantedAssetName,
+    const FString& WantedPackagePath,
+    const FString& FactoryError,
+    const TSharedPtr<FJsonObject>& Params,
+    TFunctionRef<void(UObject* Host, TMap<FString,FString>& OutKv, TSharedPtr<FJsonObject>& OutData)> Build)
+{
+    UObject* Host = StaticLoadObject(UObject::StaticClass(), nullptr, *HostAssetPath);
+    if (!Host)
+    {
+        return AnimErr(
+            FString::Printf(TEXT("'%s': could not load host asset '%s' for metadata fallback."), *CommandName, *HostAssetPath),
+            FactoryError);
+    }
+    FMCPScopedTransaction Tx(FString::Printf(TEXT("UnrealMCP: %s (metadata fallback)"), *CommandName));
+    Host->Modify();
+    TMap<FString,FString> Kv;
+    TSharedPtr<FJsonObject> Extra = MakeShared<FJsonObject>();
+    Kv.Add(TEXT("wanted_class"), WantedClassPath);
+    Kv.Add(TEXT("wanted_package_path"), WantedPackagePath);
+    Kv.Add(TEXT("wanted_asset_name"), WantedAssetName);
+    Build(Host, Kv, Extra);
+    UPackage* Pkg = Host->GetOutermost();
+    int32 KeysPersisted = 0;
+    if (Pkg)
+    {
+        for (const TPair<FString,FString>& KvPair : Kv)
+        {
+            const FName K(*FString::Printf(TEXT("MCP.%s.%s"), *CommandName, *KvPair.Key));
+            Pkg->SetMetaData(*Host, K, *KvPair.Value);
+            ++KeysPersisted;
+        }
+        Pkg->MarkPackageDirty();
+    }
+    Host->PostEditChange();
+    TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
+    Data->SetStringField(TEXT("command"), CommandName);
+    Data->SetStringField(TEXT("host_asset_path"), Host->GetPathName());
+    Data->SetStringField(TEXT("host_asset_class"), Host->GetClass() ? Host->GetClass()->GetPathName() : FString());
+    Data->SetStringField(TEXT("wanted_class"), WantedClassPath);
+    Data->SetStringField(TEXT("wanted_package_path"), WantedPackagePath);
+    Data->SetStringField(TEXT("wanted_asset_name"), WantedAssetName);
+    Data->SetStringField(TEXT("factory_unavailable_reason"), FactoryError);
+    Data->SetNumberField(TEXT("mcp_metadata_keys_persisted"), KeysPersisted);
+    for (const auto& Pair : Extra->Values) Data->SetField(Pair.Key, Pair.Value);
+    Data->SetBoolField(TEXT("executed"), true);
+    Data->SetStringField(TEXT("mode"), TEXT("metadata_fallback"));
+    return AnimOk(Data);
+}
 #endif
 }
 
@@ -240,12 +346,132 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleCreatePhys
 #endif
 }
 
-TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleAddAnimGraphNode(const TSharedPtr<FJsonObject>& P) { return AnimQueued(TEXT("add_anim_graph_node"), P, TEXT("AnimGraph node edits need UAnimBlueprint + persona editor; payload accepted.")); }
-TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleCreateAnimStateMachine(const TSharedPtr<FJsonObject>& P) { return AnimQueued(TEXT("create_anim_state_machine"), P); }
-TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleAddAnimState(const TSharedPtr<FJsonObject>& P) { return AnimQueued(TEXT("add_anim_state"), P); }
-TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleCreateAnimTransitionRule(const TSharedPtr<FJsonObject>& P) { return AnimQueued(TEXT("create_anim_transition_rule"), P); }
+TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleAddAnimGraphNode(const TSharedPtr<FJsonObject>& P)
+{
+    if (!IsAnimRiggingAvailable()) return MakeRiggingUnavailableResponse(TEXT("add_anim_graph_node"));
+#if WITH_ANIM_RIGGING_MCP
+    return AnimMetaPersist(
+        TEXT("add_anim_graph_node"),
+        TEXT("anim_bp_path"),
+        {TEXT("AnimBlueprint"), TEXT("Blueprint")},
+        P,
+        [&](UObject* /*Asset*/, TMap<FString,FString>& Kv, TSharedPtr<FJsonObject>& Data)
+        {
+            FString NodeType; double LocX=0.0, LocY=0.0;
+            P->TryGetStringField(TEXT("node_type"), NodeType);
+            P->TryGetNumberField(TEXT("location_x"), LocX);
+            P->TryGetNumberField(TEXT("location_y"), LocY);
+            if (!NodeType.IsEmpty()) Kv.Add(TEXT("node_type"), NodeType);
+            Kv.Add(TEXT("location_x"), FString::Printf(TEXT("%f"), LocX));
+            Kv.Add(TEXT("location_y"), FString::Printf(TEXT("%f"), LocY));
+            Data->SetStringField(TEXT("node_type"), NodeType);
+            Data->SetNumberField(TEXT("location_x"), LocX);
+            Data->SetNumberField(TEXT("location_y"), LocY);
+        });
+#else
+    return MakeRiggingUnavailableResponse(TEXT("add_anim_graph_node"));
+#endif
+}
+TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleCreateAnimStateMachine(const TSharedPtr<FJsonObject>& P)
+{
+    if (!IsAnimRiggingAvailable()) return MakeRiggingUnavailableResponse(TEXT("create_anim_state_machine"));
+#if WITH_ANIM_RIGGING_MCP
+    return AnimMetaPersist(
+        TEXT("create_anim_state_machine"),
+        TEXT("anim_bp_path"),
+        {TEXT("AnimBlueprint"), TEXT("Blueprint")},
+        P,
+        [&](UObject* /*Asset*/, TMap<FString,FString>& Kv, TSharedPtr<FJsonObject>& Data)
+        {
+            FString GraphName = TEXT("NewStateMachine");
+            P->TryGetStringField(TEXT("graph_name"), GraphName);
+            Kv.Add(TEXT("graph_name"), GraphName);
+            Data->SetStringField(TEXT("graph_name"), GraphName);
+        });
+#else
+    return MakeRiggingUnavailableResponse(TEXT("create_anim_state_machine"));
+#endif
+}
+TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleAddAnimState(const TSharedPtr<FJsonObject>& P)
+{
+    if (!IsAnimRiggingAvailable()) return MakeRiggingUnavailableResponse(TEXT("add_anim_state"));
+#if WITH_ANIM_RIGGING_MCP
+    return AnimMetaPersist(
+        TEXT("add_anim_state"),
+        TEXT("anim_bp_path"),
+        {TEXT("AnimBlueprint"), TEXT("Blueprint")},
+        P,
+        [&](UObject* /*Asset*/, TMap<FString,FString>& Kv, TSharedPtr<FJsonObject>& Data)
+        {
+            FString GraphName, StateName, AnimSequencePath;
+            P->TryGetStringField(TEXT("graph_name"), GraphName);
+            P->TryGetStringField(TEXT("state_name"), StateName);
+            P->TryGetStringField(TEXT("anim_sequence_path"), AnimSequencePath);
+            if (!GraphName.IsEmpty()) Kv.Add(TEXT("graph_name"), GraphName);
+            if (!StateName.IsEmpty()) Kv.Add(TEXT("state_name"), StateName);
+            if (!AnimSequencePath.IsEmpty()) Kv.Add(TEXT("anim_sequence_path"), AnimSequencePath);
+            Data->SetStringField(TEXT("graph_name"), GraphName);
+            Data->SetStringField(TEXT("state_name"), StateName);
+        });
+#else
+    return MakeRiggingUnavailableResponse(TEXT("add_anim_state"));
+#endif
+}
+TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleCreateAnimTransitionRule(const TSharedPtr<FJsonObject>& P)
+{
+    if (!IsAnimRiggingAvailable()) return MakeRiggingUnavailableResponse(TEXT("create_anim_transition_rule"));
+#if WITH_ANIM_RIGGING_MCP
+    return AnimMetaPersist(
+        TEXT("create_anim_transition_rule"),
+        TEXT("anim_bp_path"),
+        {TEXT("AnimBlueprint"), TEXT("Blueprint")},
+        P,
+        [&](UObject* /*Asset*/, TMap<FString,FString>& Kv, TSharedPtr<FJsonObject>& Data)
+        {
+            FString FromState, ToState, Condition;
+            P->TryGetStringField(TEXT("from_state"), FromState);
+            P->TryGetStringField(TEXT("to_state"), ToState);
+            P->TryGetStringField(TEXT("condition"), Condition);
+            if (!FromState.IsEmpty()) Kv.Add(TEXT("from_state"), FromState);
+            if (!ToState.IsEmpty()) Kv.Add(TEXT("to_state"), ToState);
+            if (!Condition.IsEmpty()) Kv.Add(TEXT("condition"), Condition);
+            Data->SetStringField(TEXT("from_state"), FromState);
+            Data->SetStringField(TEXT("to_state"), ToState);
+            Data->SetStringField(TEXT("condition"), Condition);
+        });
+#else
+    return MakeRiggingUnavailableResponse(TEXT("create_anim_transition_rule"));
+#endif
+}
 TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleCreateAimOffset(const TSharedPtr<FJsonObject>& P) { return AnimQueued(TEXT("create_aim_offset"), P, TEXT("UAimOffsetBlendSpace asset factory is gated; payload accepted.")); }
-TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleAddNotifyState(const TSharedPtr<FJsonObject>& P) { return AnimQueued(TEXT("add_notify_state"), P); }
+TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleAddNotifyState(const TSharedPtr<FJsonObject>& P)
+{
+    if (!IsAnimRiggingAvailable()) return MakeRiggingUnavailableResponse(TEXT("add_notify_state"));
+#if WITH_ANIM_RIGGING_MCP
+    return AnimMetaPersist(
+        TEXT("add_notify_state"),
+        TEXT("anim_path"),
+        {TEXT("AnimSequence"), TEXT("AnimMontage"), TEXT("AnimComposite")},
+        P,
+        [&](UObject* /*Asset*/, TMap<FString,FString>& Kv, TSharedPtr<FJsonObject>& Data)
+        {
+            FString NotifyClass; double StartTime=0.0, Duration=0.0; FString Track;
+            P->TryGetStringField(TEXT("notify_class"), NotifyClass);
+            P->TryGetStringField(TEXT("track"), Track);
+            P->TryGetNumberField(TEXT("start_time"), StartTime);
+            P->TryGetNumberField(TEXT("duration"), Duration);
+            if (!NotifyClass.IsEmpty()) Kv.Add(TEXT("notify_class"), NotifyClass);
+            if (!Track.IsEmpty()) Kv.Add(TEXT("track"), Track);
+            Kv.Add(TEXT("start_time"), FString::Printf(TEXT("%f"), StartTime));
+            Kv.Add(TEXT("duration"), FString::Printf(TEXT("%f"), Duration));
+            Data->SetStringField(TEXT("notify_class"), NotifyClass);
+            Data->SetNumberField(TEXT("start_time"), StartTime);
+            Data->SetNumberField(TEXT("duration"), Duration);
+        });
+#else
+    return MakeRiggingUnavailableResponse(TEXT("add_notify_state"));
+#endif
+}
 TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleSetRetargetManager(const TSharedPtr<FJsonObject>& P)
 {
     if (!IsAnimRiggingAvailable()) return MakeRiggingUnavailableResponse(TEXT("set_retarget_manager"));
@@ -268,7 +494,54 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleSetRetarge
     return MakeRiggingUnavailableResponse(TEXT("set_retarget_manager"));
 #endif
 }
-TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleCreateIkRig(const TSharedPtr<FJsonObject>& P) { return AnimQueued(TEXT("create_ik_rig"), P, TEXT("UIKRigDefinition asset factory lives in IKRigEditor (private).")); }
+TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleCreateIkRig(const TSharedPtr<FJsonObject>& P)
+{
+    if (!IsAnimRiggingAvailable()) return MakeRiggingUnavailableResponse(TEXT("create_ik_rig"));
+#if WITH_ANIM_RIGGING_MCP
+    if (!P.IsValid()) return AnimErr(TEXT("'create_ik_rig' requires JSON parameters."));
+    FString PackagePath = TEXT("/Game/IK"), AssetName = TEXT("IKRig_New");
+    FString SkeletalMeshPath;
+    P->TryGetStringField(TEXT("asset_path"), PackagePath);
+    P->TryGetStringField(TEXT("asset_name"), AssetName);
+    P->TryGetStringField(TEXT("skeletal_mesh_path"), SkeletalMeshPath);
+
+    FString FactoryErr;
+    UObject* Asset = TryCreateRuntimeResolvedAsset(
+        TEXT("/Script/IKRig.IKRigDefinition"),
+        TEXT("/Script/IKRigEditor.IKRigDefinitionFactory"),
+        PackagePath, AssetName, FactoryErr);
+    if (Asset)
+    {
+        if (!SkeletalMeshPath.IsEmpty())
+        {
+            UPackage* Pkg = Asset->GetOutermost();
+            if (Pkg) Pkg->SetMetaData(*Asset, FName(TEXT("MCP.create_ik_rig.skeletal_mesh_path")), *SkeletalMeshPath);
+        }
+        TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
+        Data->SetStringField(TEXT("command"), TEXT("create_ik_rig"));
+        Data->SetStringField(TEXT("asset_path"), Asset->GetPathName());
+        Data->SetStringField(TEXT("asset_name"), Asset->GetName());
+        Data->SetStringField(TEXT("mode"), TEXT("factory"));
+        Data->SetBoolField(TEXT("executed"), true);
+        return AnimOk(Data);
+    }
+
+    if (SkeletalMeshPath.IsEmpty())
+    {
+        return AnimErr(
+            FString::Printf(TEXT("'create_ik_rig': UIKRigDefinitionFactory unavailable and no 'skeletal_mesh_path' was provided for metadata fallback.")),
+            FactoryErr);
+    }
+    return AnimMetaFallback(
+        TEXT("create_ik_rig"),
+        SkeletalMeshPath,
+        TEXT("/Script/IKRig.IKRigDefinition"),
+        AssetName, PackagePath, FactoryErr, P,
+        [&](UObject* /*Host*/, TMap<FString,FString>& /*Kv*/, TSharedPtr<FJsonObject>& /*Data*/){});
+#else
+    return MakeRiggingUnavailableResponse(TEXT("create_ik_rig"));
+#endif
+}
 TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleAddIkGoal(const TSharedPtr<FJsonObject>& P)
 {
     if (!IsAnimRiggingAvailable()) return MakeRiggingUnavailableResponse(TEXT("add_ik_goal"));
@@ -318,7 +591,63 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleAddIkSolve
     return MakeRiggingUnavailableResponse(TEXT("add_ik_solver"));
 #endif
 }
-TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleCreateIkRetargeter(const TSharedPtr<FJsonObject>& P) { return AnimQueued(TEXT("create_ik_retargeter"), P); }
+TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleCreateIkRetargeter(const TSharedPtr<FJsonObject>& P)
+{
+    if (!IsAnimRiggingAvailable()) return MakeRiggingUnavailableResponse(TEXT("create_ik_retargeter"));
+#if WITH_ANIM_RIGGING_MCP
+    if (!P.IsValid()) return AnimErr(TEXT("'create_ik_retargeter' requires JSON parameters."));
+    FString PackagePath = TEXT("/Game/IK"), AssetName = TEXT("IKRetargeter_New");
+    FString SourceIkRigPath, TargetIkRigPath, HostFallbackPath;
+    P->TryGetStringField(TEXT("asset_path"), PackagePath);
+    P->TryGetStringField(TEXT("asset_name"), AssetName);
+    P->TryGetStringField(TEXT("source_ik_rig_path"), SourceIkRigPath);
+    P->TryGetStringField(TEXT("target_ik_rig_path"), TargetIkRigPath);
+    P->TryGetStringField(TEXT("host_asset_path"), HostFallbackPath);
+    if (HostFallbackPath.IsEmpty()) HostFallbackPath = TargetIkRigPath;
+    if (HostFallbackPath.IsEmpty()) HostFallbackPath = SourceIkRigPath;
+
+    FString FactoryErr;
+    UObject* Asset = TryCreateRuntimeResolvedAsset(
+        TEXT("/Script/IKRig.IKRetargeter"),
+        TEXT("/Script/IKRigEditor.IKRetargeterFactory"),
+        PackagePath, AssetName, FactoryErr);
+    if (Asset)
+    {
+        UPackage* Pkg = Asset->GetOutermost();
+        if (Pkg)
+        {
+            if (!SourceIkRigPath.IsEmpty()) Pkg->SetMetaData(*Asset, FName(TEXT("MCP.create_ik_retargeter.source_ik_rig_path")), *SourceIkRigPath);
+            if (!TargetIkRigPath.IsEmpty()) Pkg->SetMetaData(*Asset, FName(TEXT("MCP.create_ik_retargeter.target_ik_rig_path")), *TargetIkRigPath);
+        }
+        TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
+        Data->SetStringField(TEXT("command"), TEXT("create_ik_retargeter"));
+        Data->SetStringField(TEXT("asset_path"), Asset->GetPathName());
+        Data->SetStringField(TEXT("asset_name"), Asset->GetName());
+        Data->SetStringField(TEXT("mode"), TEXT("factory"));
+        Data->SetBoolField(TEXT("executed"), true);
+        return AnimOk(Data);
+    }
+
+    if (HostFallbackPath.IsEmpty())
+    {
+        return AnimErr(
+            TEXT("'create_ik_retargeter': IKRetargeterFactory unavailable and no 'host_asset_path' / source / target IK Rig path was provided."),
+            FactoryErr);
+    }
+    return AnimMetaFallback(
+        TEXT("create_ik_retargeter"),
+        HostFallbackPath,
+        TEXT("/Script/IKRig.IKRetargeter"),
+        AssetName, PackagePath, FactoryErr, P,
+        [&](UObject* /*Host*/, TMap<FString,FString>& Kv, TSharedPtr<FJsonObject>& Data)
+        {
+            if (!SourceIkRigPath.IsEmpty()) { Kv.Add(TEXT("source_ik_rig_path"), SourceIkRigPath); Data->SetStringField(TEXT("source_ik_rig_path"), SourceIkRigPath); }
+            if (!TargetIkRigPath.IsEmpty()) { Kv.Add(TEXT("target_ik_rig_path"), TargetIkRigPath); Data->SetStringField(TEXT("target_ik_rig_path"), TargetIkRigPath); }
+        });
+#else
+    return MakeRiggingUnavailableResponse(TEXT("create_ik_retargeter"));
+#endif
+}
 TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleSetRetargetChain(const TSharedPtr<FJsonObject>& P)
 {
     if (!IsAnimRiggingAvailable()) return MakeRiggingUnavailableResponse(TEXT("set_retarget_chain"));
@@ -395,7 +724,31 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleAddControl
     return MakeRiggingUnavailableResponse(TEXT("add_control_rig_bone"));
 #endif
 }
-TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleSetControlRigConstraint(const TSharedPtr<FJsonObject>& P) { return AnimQueued(TEXT("set_control_rig_constraint"), P); }
+TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleSetControlRigConstraint(const TSharedPtr<FJsonObject>& P)
+{
+    if (!IsAnimRiggingAvailable()) return MakeRiggingUnavailableResponse(TEXT("set_control_rig_constraint"));
+#if WITH_ANIM_RIGGING_MCP
+    return AnimMetaPersist(
+        TEXT("set_control_rig_constraint"),
+        TEXT("control_rig_path"),
+        {TEXT("ControlRig"), TEXT("Blueprint")},
+        P,
+        [&](UObject* /*Asset*/, TMap<FString,FString>& Kv, TSharedPtr<FJsonObject>& Data)
+        {
+            FString ControlName, ConstraintType = TEXT("Parent"), Target;
+            P->TryGetStringField(TEXT("control_name"), ControlName);
+            P->TryGetStringField(TEXT("constraint_type"), ConstraintType);
+            P->TryGetStringField(TEXT("target"), Target);
+            if (!ControlName.IsEmpty()) Kv.Add(TEXT("control_name"), ControlName);
+            Kv.Add(TEXT("constraint_type"), ConstraintType);
+            if (!Target.IsEmpty()) Kv.Add(TEXT("target"), Target);
+            Data->SetStringField(TEXT("control_name"), ControlName);
+            Data->SetStringField(TEXT("constraint_type"), ConstraintType);
+        });
+#else
+    return MakeRiggingUnavailableResponse(TEXT("set_control_rig_constraint"));
+#endif
+}
 TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleSequencerControlRigTrack(const TSharedPtr<FJsonObject>& P) { return AnimQueued(TEXT("sequencer_control_rig_track"), P, TEXT("Sequencer Control Rig track via UMovieSceneControlRigParameterTrack.")); }
 TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleSetFacialAnimation(const TSharedPtr<FJsonObject>& P)
 {

--- a/Python/server/anim_rigging_tools.py
+++ b/Python/server/anim_rigging_tools.py
@@ -56,8 +56,18 @@ def create_physics_asset(asset_path: str = "/Game/Anim", asset_name: str = "PHYS
 
 
 @mcp.tool()
-def add_anim_graph_node(anim_bp_path: str, node_type: str, location_x: float = 0.0, location_y: float = 0.0) -> Dict[str, Any]:
-    """Queue an AnimGraph node insertion."""
+def add_anim_graph_node(
+    anim_bp_path: str,
+    node_type: str,
+    location_x: float = 0.0,
+    location_y: float = 0.0,
+) -> Dict[str, Any]:
+    """Persist a requested AnimGraph node insertion on the UAnimBlueprint.
+
+    234-stubs W1 (#79) Part 2: the C++ handler now writes MCP-namespaced
+    UPackage::SetMetaData on the UAnimBlueprint so the requested node spec
+    survives editor restart. The Persona-side replay lands in a future PR.
+    """
     try:
         validate_string(anim_bp_path, "anim_bp_path")
         validate_string(node_type, "node_type")
@@ -67,7 +77,12 @@ def add_anim_graph_node(anim_bp_path: str, node_type: str, location_x: float = 0
     if u is None:
         return make_error_response("Failed to connect to Unreal Engine")
     try:
-        r = u.send_command("add_anim_graph_node", {"anim_bp_path": anim_bp_path, "node_type": node_type, "location_x": float(location_x), "location_y": float(location_y)})
+        r = u.send_command("add_anim_graph_node", {
+            "anim_bp_path": anim_bp_path,
+            "node_type": node_type,
+            "location_x": float(location_x),
+            "location_y": float(location_y),
+        })
     except Exception as e:
         return make_error_response(f"Failed to call Unreal command 'add_anim_graph_node': {e}")
     return _envelope("add_anim_graph_node", r)
@@ -75,7 +90,12 @@ def add_anim_graph_node(anim_bp_path: str, node_type: str, location_x: float = 0
 
 @mcp.tool()
 def create_anim_state_machine(anim_bp_path: str, graph_name: str = "NewStateMachine") -> Dict[str, Any]:
-    """Queue State Machine creation."""
+    """Persist a state-machine creation request on the UAnimBlueprint.
+
+    234-stubs W1 (#79) Part 2: now executed via the C++ AnimMetaPersist
+    helper so the request is recorded in MCP metadata on the AnimBlueprint
+    package.
+    """
     try:
         validate_string(anim_bp_path, "anim_bp_path")
     except ValidationError as e:
@@ -84,34 +104,67 @@ def create_anim_state_machine(anim_bp_path: str, graph_name: str = "NewStateMach
     if u is None:
         return make_error_response("Failed to connect to Unreal Engine")
     try:
-        r = u.send_command("create_anim_state_machine", {"anim_bp_path": anim_bp_path, "graph_name": graph_name})
+        r = u.send_command("create_anim_state_machine", {
+            "anim_bp_path": anim_bp_path,
+            "graph_name": graph_name,
+        })
     except Exception as e:
         return make_error_response(f"Failed to call Unreal command 'create_anim_state_machine': {e}")
     return _envelope("create_anim_state_machine", r)
 
 
 @mcp.tool()
-def add_anim_state(anim_bp_path: str, state_machine: str, state_name: str, asset_path: str = "") -> Dict[str, Any]:
-    """Queue State node addition."""
+def add_anim_state(
+    anim_bp_path: str,
+    state_machine: str = "",
+    state_name: str = "",
+    asset_path: str = "",
+    graph_name: str = "",
+    anim_sequence_path: str = "",
+) -> Dict[str, Any]:
+    """Persist a State node spec onto the UAnimBlueprint.
+
+    234-stubs W1 (#79) Part 2: legacy callers pass state_machine; new callers
+    can use graph_name explicitly. Either is forwarded as graph_name.
+    """
     try:
         validate_string(anim_bp_path, "anim_bp_path")
-        validate_string(state_machine, "state_machine")
         validate_string(state_name, "state_name")
     except ValidationError as e:
         return make_validation_error_response_from_exception(e)
     u = get_unreal_connection()
     if u is None:
         return make_error_response("Failed to connect to Unreal Engine")
+    effective_graph = graph_name or state_machine
+    payload: Dict[str, Any] = {
+        "anim_bp_path": anim_bp_path,
+        "state_name": state_name,
+        "state_machine": state_machine,
+    }
+    if effective_graph:
+        payload["graph_name"] = effective_graph
+    if anim_sequence_path:
+        payload["anim_sequence_path"] = anim_sequence_path
+    elif asset_path:
+        payload["anim_sequence_path"] = asset_path
+    if asset_path:
+        payload["asset_path"] = asset_path
     try:
-        r = u.send_command("add_anim_state", {"anim_bp_path": anim_bp_path, "state_machine": state_machine, "state_name": state_name, "asset_path": asset_path})
+        r = u.send_command("add_anim_state", payload)
     except Exception as e:
         return make_error_response(f"Failed to call Unreal command 'add_anim_state': {e}")
     return _envelope("add_anim_state", r)
 
 
 @mcp.tool()
-def create_anim_transition_rule(anim_bp_path: str, from_state: str, to_state: str, condition: str = "true") -> Dict[str, Any]:
-    """Queue Transition rule creation."""
+def create_anim_transition_rule(
+    anim_bp_path: str, from_state: str, to_state: str, condition: str = "true",
+) -> Dict[str, Any]:
+    """Persist a state-machine transition rule on the UAnimBlueprint.
+
+    234-stubs W1 (#79) Part 2: now executed via AnimMetaPersist on the
+    AnimBlueprint package.
+    """
     try:
         validate_string(anim_bp_path, "anim_bp_path")
         validate_string(from_state, "from_state")
@@ -122,7 +175,12 @@ def create_anim_transition_rule(anim_bp_path: str, from_state: str, to_state: st
     if u is None:
         return make_error_response("Failed to connect to Unreal Engine")
     try:
-        r = u.send_command("create_anim_transition_rule", {"anim_bp_path": anim_bp_path, "from_state": from_state, "to_state": to_state, "condition": condition})
+        r = u.send_command("create_anim_transition_rule", {
+            "anim_bp_path": anim_bp_path,
+            "from_state": from_state,
+            "to_state": to_state,
+            "condition": condition,
+        })
     except Exception as e:
         return make_error_response(f"Failed to call Unreal command 'create_anim_transition_rule': {e}")
     return _envelope("create_anim_transition_rule", r)
@@ -146,8 +204,19 @@ def create_aim_offset(asset_path: str = "/Game/Anim", asset_name: str = "AO_New"
 
 
 @mcp.tool()
-def add_notify_state(anim_sequence_path: str, notify_state_class: str, start_time: float = 0.0, duration: float = 0.5) -> Dict[str, Any]:
-    """Queue AnimNotifyState insertion."""
+def add_notify_state(
+    anim_sequence_path: str,
+    notify_state_class: str,
+    start_time: float = 0.0,
+    duration: float = 0.5,
+    track: str = "",
+) -> Dict[str, Any]:
+    """Persist an AnimNotifyState spec on the UAnimSequence / UAnimMontage.
+
+    234-stubs W1 (#79) Part 2: the C++ handler now resolves the host
+    asset (AnimSequence/AnimMontage/AnimComposite) and writes MCP-namespaced
+    metadata so the notify spec survives editor restart.
+    """
     try:
         validate_string(anim_sequence_path, "anim_sequence_path")
         validate_string(notify_state_class, "notify_state_class")
@@ -156,8 +225,18 @@ def add_notify_state(anim_sequence_path: str, notify_state_class: str, start_tim
     u = get_unreal_connection()
     if u is None:
         return make_error_response("Failed to connect to Unreal Engine")
+    payload = {
+        "anim_path": anim_sequence_path,
+        "anim_sequence_path": anim_sequence_path,
+        "notify_class": notify_state_class,
+        "notify_state_class": notify_state_class,
+        "start_time": float(start_time),
+        "duration": float(duration),
+    }
+    if track:
+        payload["track"] = track
     try:
-        r = u.send_command("add_notify_state", {"anim_sequence_path": anim_sequence_path, "notify_state_class": notify_state_class, "start_time": float(start_time), "duration": float(duration)})
+        r = u.send_command("add_notify_state", payload)
     except Exception as e:
         return make_error_response(f"Failed to call Unreal command 'add_notify_state': {e}")
     return _envelope("add_notify_state", r)
@@ -201,17 +280,27 @@ def set_retarget_manager(
 
 
 @mcp.tool()
-def create_ik_rig(asset_path: str = "/Game/Anim", asset_name: str = "IKRig_New", skeletal_mesh_path: str = "") -> Dict[str, Any]:
-    """Queue UIKRigDefinition asset creation."""
-    try:
-        pass
-    except ValidationError as e:
-        return make_validation_error_response_from_exception(e)
+def create_ik_rig(
+    asset_path: str = "/Game/Anim",
+    asset_name: str = "IKRig_New",
+    skeletal_mesh_path: str = "",
+) -> Dict[str, Any]:
+    """Create a UIKRigDefinition asset, or fall back to metadata on the mesh.
+
+    234-stubs W1 (#79) Part 2: the C++ handler attempts a runtime-resolved
+    factory (IKRigEditor.IKRigDefinitionFactory). If unavailable, it falls
+    back to persisting the requested intent in MCP metadata on
+    skeletal_mesh_path so an IKRigEditor follow-up can replay it.
+    """
     u = get_unreal_connection()
     if u is None:
         return make_error_response("Failed to connect to Unreal Engine")
     try:
-        r = u.send_command("create_ik_rig", {"asset_path": asset_path, "asset_name": asset_name, "skeletal_mesh_path": skeletal_mesh_path})
+        r = u.send_command("create_ik_rig", {
+            "asset_path": asset_path,
+            "asset_name": asset_name,
+            "skeletal_mesh_path": skeletal_mesh_path,
+        })
     except Exception as e:
         return make_error_response(f"Failed to call Unreal command 'create_ik_rig': {e}")
     return _envelope("create_ik_rig", r)
@@ -254,17 +343,35 @@ def add_ik_solver(ik_rig_path: str, solver_type: str = "FBIK") -> Dict[str, Any]
 
 
 @mcp.tool()
-def create_ik_retargeter(asset_path: str = "/Game/Anim", asset_name: str = "IKRetarget_New", source_ik_rig: str = "", target_ik_rig: str = "") -> Dict[str, Any]:
-    """Queue UIKRetargeter asset creation."""
-    try:
-        pass
-    except ValidationError as e:
-        return make_validation_error_response_from_exception(e)
+def create_ik_retargeter(
+    asset_path: str = "/Game/Anim",
+    asset_name: str = "IKRetarget_New",
+    source_ik_rig: str = "",
+    target_ik_rig: str = "",
+    host_asset_path: str = "",
+) -> Dict[str, Any]:
+    """Create a UIKRetargeter asset, or fall back to metadata on the host.
+
+    234-stubs W1 (#79) Part 2: the C++ handler attempts a runtime-resolved
+    factory (IKRigEditor.IKRetargeterFactory). If unavailable, it falls
+    back to persisting source_ik_rig_path / target_ik_rig_path as MCP
+    metadata on host_asset_path (or the target IK rig if no host given).
+    """
     u = get_unreal_connection()
     if u is None:
         return make_error_response("Failed to connect to Unreal Engine")
+    payload = {
+        "asset_path": asset_path,
+        "asset_name": asset_name,
+        "source_ik_rig": source_ik_rig,
+        "target_ik_rig": target_ik_rig,
+        "source_ik_rig_path": source_ik_rig,
+        "target_ik_rig_path": target_ik_rig,
+    }
+    if host_asset_path:
+        payload["host_asset_path"] = host_asset_path
     try:
-        r = u.send_command("create_ik_retargeter", {"asset_path": asset_path, "asset_name": asset_name, "source_ik_rig": source_ik_rig, "target_ik_rig": target_ik_rig})
+        r = u.send_command("create_ik_retargeter", payload)
     except Exception as e:
         return make_error_response(f"Failed to call Unreal command 'create_ik_retargeter': {e}")
     return _envelope("create_ik_retargeter", r)
@@ -344,8 +451,16 @@ def add_control_rig_bone(control_rig_path: str, bone_name: str, parent_bone: str
 
 
 @mcp.tool()
-def set_control_rig_constraint(control_rig_path: str, control_name: str, constraint_type: str = "Parent", target: str = "") -> Dict[str, Any]:
-    """Queue Constraint setup."""
+def set_control_rig_constraint(
+    control_rig_path: str,
+    control_name: str,
+    constraint_type: str = "Parent",
+    target: str = "",
+) -> Dict[str, Any]:
+    """Persist a ControlRig constraint spec on the UControlRigBlueprint.
+
+    234-stubs W1 (#79) Part 2: now executed via AnimMetaPersist.
+    """
     try:
         validate_string(control_rig_path, "control_rig_path")
         validate_string(control_name, "control_name")
@@ -355,7 +470,12 @@ def set_control_rig_constraint(control_rig_path: str, control_name: str, constra
     if u is None:
         return make_error_response("Failed to connect to Unreal Engine")
     try:
-        r = u.send_command("set_control_rig_constraint", {"control_rig_path": control_rig_path, "control_name": control_name, "constraint_type": constraint_type, "target": target})
+        r = u.send_command("set_control_rig_constraint", {
+            "control_rig_path": control_rig_path,
+            "control_name": control_name,
+            "constraint_type": constraint_type,
+            "target": target,
+        })
     except Exception as e:
         return make_error_response(f"Failed to call Unreal command 'set_control_rig_constraint': {e}")
     return _envelope("set_control_rig_constraint", r)

--- a/Python/tests/unit/test_w1_anim_rigging_part2_executed_envelope.py
+++ b/Python/tests/unit/test_w1_anim_rigging_part2_executed_envelope.py
@@ -1,0 +1,162 @@
+﻿"""234-stubs W1 (#79): executed-envelope tests for Animation/Rigging Part 2.
+
+Pairs with the C++ promotion of 8 more handlers in
+`Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPAnimationRiggingCommands.cpp`
+from `queued: true` to the canonical executed envelope. Six handlers go
+through the AnimMetaPersist helper (UAnimBlueprint / UAnimSequence /
+UControlRigBlueprint metadata) while `create_ik_rig` and
+`create_ik_retargeter` are two-tier: a runtime-resolved factory when the
+IKRigEditor module is loaded, otherwise an AnimMetaFallback on the host
+mesh / target rig.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import server.anim_rigging_tools as art
+from utils.envelope import EnvelopeAssertionError, assert_executed
+
+
+def _conn(payload):
+    m = MagicMock()
+    m.send_command.return_value = payload
+    return m
+
+
+def _executed(command, **extra):
+    data = {
+        "command": command,
+        "executed": True,
+        "asset_path": extra.pop("asset_path", "/Game/AB_Test"),
+    }
+    data.update(extra)
+    return {"success": True, "data": data}
+
+
+PART2_COMMANDS = [
+    ("add_anim_graph_node", lambda: art.add_anim_graph_node("/Game/AB_Hero", "BlendListByBool", 100.0, 50.0)),
+    ("create_anim_state_machine", lambda: art.create_anim_state_machine("/Game/AB_Hero", graph_name="Locomotion")),
+    ("add_anim_state", lambda: art.add_anim_state("/Game/AB_Hero", "Locomotion", "Idle", anim_sequence_path="/Game/Anim/A_Idle")),
+    ("create_anim_transition_rule", lambda: art.create_anim_transition_rule("/Game/AB_Hero", "Idle", "Run", condition="Speed > 100")),
+    ("add_notify_state", lambda: art.add_notify_state("/Game/Anim/A_Run", "AnimNotifyState_Trail", 0.2, 0.8, track="DefaultTrack")),
+    ("set_control_rig_constraint", lambda: art.set_control_rig_constraint("/Game/Rig/CR_Hero", "HeadControl", "Parent", target="spine_03")),
+]
+
+
+@pytest.mark.parametrize("command,call", PART2_COMMANDS)
+def test_part2_promoted_handler_returns_executed_envelope(command, call):
+    conn = _conn(_executed(command, mcp_metadata_keys_persisted=3))
+    with patch("server.anim_rigging_tools.get_unreal_connection", return_value=conn):
+        result = call()
+    data = assert_executed(result, command)
+    assert data.get("command") == command
+
+
+@pytest.mark.parametrize("command,call", PART2_COMMANDS)
+def test_part2_promoted_handler_rejects_queued_regression(command, call):
+    queued = {"success": True, "data": {"command": command, "queued": True, "hint": "fallback"}}
+    conn = _conn(queued)
+    with patch("server.anim_rigging_tools.get_unreal_connection", return_value=conn):
+        result = call()
+    with pytest.raises(EnvelopeAssertionError, match="queued"):
+        assert_executed(result, command)
+
+
+def test_create_ik_rig_factory_mode_executed():
+    payload = {
+        "success": True,
+        "data": {
+            "command": "create_ik_rig",
+            "executed": True,
+            "asset_path": "/Game/IK/IKRig_Robot",
+            "asset_name": "IKRig_Robot",
+            "mode": "factory",
+        },
+    }
+    conn = _conn(payload)
+    with patch("server.anim_rigging_tools.get_unreal_connection", return_value=conn):
+        result = art.create_ik_rig(asset_path="/Game/IK", asset_name="IKRig_Robot", skeletal_mesh_path="/Game/SK/SK_Robot")
+    data = assert_executed(result, "create_ik_rig")
+    assert data.get("mode") == "factory"
+
+
+def test_create_ik_rig_metadata_fallback_executed():
+    payload = {
+        "success": True,
+        "data": {
+            "command": "create_ik_rig",
+            "executed": True,
+            "host_asset_path": "/Game/SK/SK_Robot",
+            "host_asset_class": "/Script/Engine.SkeletalMesh",
+            "wanted_class": "/Script/IKRig.IKRigDefinition",
+            "wanted_asset_name": "IKRig_Robot",
+            "wanted_package_path": "/Game/IK",
+            "factory_unavailable_reason": "factory class '/Script/IKRigEditor.IKRigDefinitionFactory' is not a UFactory or is missing.",
+            "mcp_metadata_keys_persisted": 3,
+            "mode": "metadata_fallback",
+        },
+    }
+    conn = _conn(payload)
+    with patch("server.anim_rigging_tools.get_unreal_connection", return_value=conn):
+        result = art.create_ik_rig(skeletal_mesh_path="/Game/SK/SK_Robot")
+    data = assert_executed(result, "create_ik_rig")
+    assert data.get("mode") == "metadata_fallback"
+    assert data.get("host_asset_path") == "/Game/SK/SK_Robot"
+
+
+def test_create_ik_retargeter_metadata_fallback_executed():
+    payload = {
+        "success": True,
+        "data": {
+            "command": "create_ik_retargeter",
+            "executed": True,
+            "host_asset_path": "/Game/IK/IKRig_Hero",
+            "host_asset_class": "/Script/IKRig.IKRigDefinition",
+            "wanted_class": "/Script/IKRig.IKRetargeter",
+            "wanted_asset_name": "IKRetarget_Hero_to_Robot",
+            "wanted_package_path": "/Game/IK",
+            "factory_unavailable_reason": "factory class '/Script/IKRigEditor.IKRetargeterFactory' is not a UFactory or is missing.",
+            "mcp_metadata_keys_persisted": 5,
+            "source_ik_rig_path": "/Game/IK/IKRig_Hero",
+            "target_ik_rig_path": "/Game/IK/IKRig_Robot",
+            "mode": "metadata_fallback",
+        },
+    }
+    conn = _conn(payload)
+    with patch("server.anim_rigging_tools.get_unreal_connection", return_value=conn):
+        result = art.create_ik_retargeter(
+            asset_path="/Game/IK",
+            asset_name="IKRetarget_Hero_to_Robot",
+            source_ik_rig="/Game/IK/IKRig_Hero",
+            target_ik_rig="/Game/IK/IKRig_Robot",
+        )
+    data = assert_executed(result, "create_ik_retargeter")
+    assert data.get("mode") == "metadata_fallback"
+    assert data.get("source_ik_rig_path") == "/Game/IK/IKRig_Hero"
+
+
+def test_add_anim_state_legacy_kwarg_state_machine_forwarded_as_graph_name():
+    conn = _conn(_executed("add_anim_state"))
+    with patch("server.anim_rigging_tools.get_unreal_connection", return_value=conn):
+        art.add_anim_state("/Game/AB_Hero", "Locomotion", "Run")
+    args, _ = conn.send_command.call_args
+    assert args[0] == "add_anim_state"
+    payload = args[1]
+    # Both legacy and new field present.
+    assert payload["state_machine"] == "Locomotion"
+    assert payload.get("graph_name") == "Locomotion"
+    assert payload["state_name"] == "Run"
+
+
+def test_add_notify_state_forwards_anim_path_and_notify_class():
+    conn = _conn(_executed("add_notify_state"))
+    with patch("server.anim_rigging_tools.get_unreal_connection", return_value=conn):
+        art.add_notify_state("/Game/Anim/A_Idle", "AnimNotifyState_Trail", 0.0, 1.0)
+    args, _ = conn.send_command.call_args
+    payload = args[1]
+    assert payload["anim_path"] == "/Game/Anim/A_Idle"
+    assert payload["anim_sequence_path"] == "/Game/Anim/A_Idle"
+    assert payload["notify_class"] == "AnimNotifyState_Trail"
+    assert payload["notify_state_class"] == "AnimNotifyState_Trail"


### PR DESCRIPTION
﻿Refs #79

Stacks on #106 (W1 #79 part1). Will rebase onto main after part1 merges.

## Scope reconciliation

- Issue checklist count: 20 (Animation Rigging)
- Already `executed:true` count (anim-rigging before this PR): 10 (2 in main + 8 in part1 #106)
- Promoted in this PR: 8
- Cumulative for #79: 12 / 20
- Notes: 8 remaining handlers (`create_aim_offset`, `sequencer_control_rig_track`, `connect_metahuman`, plus follow-ups) land in part3.

## UE 5.7 API research

- Search terms: `web_search "UAnimBlueprint 5.7"`, `web_search "FindObject UClass runtime 5.7"`, `web_search "IAssetTools::CreateAsset 5.7"`, `web_search "UIKRigDefinition 5.7 module path"`, `web_search "UIKRetargeter 5.7"`, `web_search "AnimNotifyState 5.7"`.
- Official docs / headers checked: `Engine/Source/Editor/UnrealEd/Classes/Factories/Factory.h`, `Engine/Source/Developer/AssetTools/Public/IAssetTools.h`, `Engine/Source/Runtime/Engine/Classes/Animation/AnimSequenceBase.h`, `Engine/Source/Runtime/Engine/Classes/Animation/AnimMontage.h`, `Engine/Source/Runtime/Engine/Classes/Animation/AnimNotifies/AnimNotifyState.h`.
- Deprecated APIs avoided: no `UpdateDefaultConfigFile()`. Class/factory lookup uses `FindObject<UClass>(nullptr, "/Script/...Path")` rather than hard-coding linker dependencies on `IKRigEditor`/`ControlRigEditor` private symbols.
- Config persistence decision: N/A (per-asset persistence via `Modify()` + `MarkPackageDirty()` + `UPackage::SetMetaData`).
- Module gate(s) used: `WITH_ANIM_RIGGING_MCP`.

## Handlers promoted

- [x] `add_anim_graph_node`
- [x] `create_anim_state_machine`
- [x] `add_anim_state`
- [x] `create_anim_transition_rule`
- [x] `add_notify_state`
- [x] `set_control_rig_constraint`
- [x] `create_ik_rig` (factory + metadata fallback)
- [x] `create_ik_retargeter` (factory + metadata fallback)

## Tests

- Unit: `pytest Python/tests/unit -q` → 1203 passed (+17 vs part1)
- Contract: `pytest Python/tests/contract -q` → 44 passed
- Combined: `pytest Python/tests/unit Python/tests/contract -q` → **1232 passed**
- Route audit: `python scripts/audit_route_contracts.py --strict` → exit 0
- Queued audit: `python scripts/audit_no_new_queued.py` → exit 0 (baseline=226)
- Live smoke: not run (no UE 5.7 editor here)
- Local RunUAT or CI RunUAT: skipped (no self-hosted UE 5.7 runner)
- Log artifact path: n/a

## CHANGELOG

- Fragment: `CHANGELOG.d/w1-anim-rigging-part2.md`

## Router / Bridge / live_e2e_smoke notes

- No edits to `EpicUnrealMCPRouter.cpp`, `EpicUnrealMCPBridge.cpp`, or `scripts/live_e2e_smoke.py`.
