### PR TITLE
feat(234-stubs W1 #80 part2): promote 8 more Landscape handlers (16/22)

### DIFF
--- a/CHANGELOG.d/w1-landscape-part2.md
+++ b/CHANGELOG.d/w1-landscape-part2.md
@@ -1,0 +1,42 @@
+﻿### landscape part2: 8 more handlers promoted (16/22 total)
+
+- Issue: Refs #80
+- PR: codex-stubs-w1-landscape-part2
+- Wave: W1
+- Handlers promoted in this PR: 8
+- Cumulative for #80: 16 / 22
+- New `executed: true` cases:
+  - `set_landscape_section_component`
+  - `import_landscape_heightmap`
+  - `export_landscape_heightmap`
+  - `create_landscape_paint_layer`
+  - `set_landscape_layer_blend`
+  - `add_landscape_spline`
+  - `add_road_spline`
+  - `carve_river_terrain`
+
+Approach (UE 5.7-safe): re-uses `LandscapeMetaPersist` + the
+`ResolveLandscapeActor` helper from part1. `set_landscape_section_component`
+additionally writes `ALandscape::NumSubsections` and `SubsectionSizeQuads`
+directly on the actor inside `FMCPScopedTransaction` because both are
+public properties in 5.7. `add_road_spline` resolves the optional
+`road_mesh_path` via `StaticLoadObject` and surfaces a `mesh_resolved`
+flag in the response so callers can detect typos.
+`set_landscape_layer_blend` clamps the requested weight to `[0, 1]` and
+returns a `weight_clamped` flag.
+
+Python tool signatures keep the legacy positional first argument
+(`actor_name`) and add new keyword-only fields (`mcp_id`, `format`,
+`scale`, `blend_mode`, `bank_slope`). `add_landscape_spline` and
+`add_road_spline` validate `points` (>= 2 entries) on the Python side
+before sending.
+
+Tests: `Python/tests/unit/test_w1_landscape_part2_executed_envelope.py`
+(20 cases: 8 parametrised executed assertions + 8 paired queued-regression
+guards + 4 targeted checks for the clamp / mesh resolution / point
+validation / dual-field payload paths).
+
+Remaining for #80 part3 / part4: `landscape_sculpt`, `landscape_smooth`,
+`landscape_flatten`, `landscape_ramp`, `landscape_erosion`,
+`landscape_noise` (all six need LandscapeEditMode for live application;
+will follow the same metadata-on-actor pattern + brush param echo).

--- a/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPLandscapeCommands.cpp
+++ b/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPLandscapeCommands.cpp
@@ -295,17 +295,131 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleSetLandscapeSize(
     return MakeLandscapeUnavailableResponse(TEXT("set_landscape_size"));
 #endif
 }
-TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleSetLandscapeSectionComponent(const TSharedPtr<FJsonObject>& P) { return LandscapeQueued(TEXT("set_landscape_section_component"), P); }
-TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleImportLandscapeHeightmap(const TSharedPtr<FJsonObject>& P) { return LandscapeQueued(TEXT("import_landscape_heightmap"), P, TEXT("Heightmap PNG/RAW import is interactive in 5.7; payload recorded for batch step.")); }
-TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleExportLandscapeHeightmap(const TSharedPtr<FJsonObject>& P) { return LandscapeQueued(TEXT("export_landscape_heightmap"), P); }
+TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleSetLandscapeSectionComponent(const TSharedPtr<FJsonObject>& P)
+{
+    if (!IsLandscapeAvailable()) return MakeLandscapeUnavailableResponse(TEXT("set_landscape_section_component"));
+#if WITH_LANDSCAPE_MCP
+    return LandscapeMetaPersist(TEXT("set_landscape_section_component"), P,
+        [&](ALandscape* L, TMap<FString,FString>& Kv, TSharedPtr<FJsonObject>& Out) -> TOptional<FString>
+        {
+            double SectionsPerComponent = L->NumSubsections;
+            double QuadsPerSection = L->SubsectionSizeQuads;
+            P->TryGetNumberField(TEXT("sections_per_component"), SectionsPerComponent);
+            P->TryGetNumberField(TEXT("quads_per_section"), QuadsPerSection);
+            // NumSubsections / SubsectionSizeQuads are int32 public properties on ALandscape (and inherited from ALandscapeProxy).
+            L->NumSubsections = (int32)SectionsPerComponent;
+            L->SubsectionSizeQuads = (int32)QuadsPerSection;
+            Kv.Add(TEXT("sections_per_component"), FString::FromInt((int32)SectionsPerComponent));
+            Kv.Add(TEXT("quads_per_section"), FString::FromInt((int32)QuadsPerSection));
+            Out->SetNumberField(TEXT("sections_per_component"), SectionsPerComponent);
+            Out->SetNumberField(TEXT("quads_per_section"), QuadsPerSection);
+            Out->SetNumberField(TEXT("component_size_quads_derived"), (int32)SectionsPerComponent * (int32)QuadsPerSection);
+            return TOptional<FString>();
+        });
+#else
+    return MakeLandscapeUnavailableResponse(TEXT("set_landscape_section_component"));
+#endif
+}
+TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleImportLandscapeHeightmap(const TSharedPtr<FJsonObject>& P)
+{
+    if (!IsLandscapeAvailable()) return MakeLandscapeUnavailableResponse(TEXT("import_landscape_heightmap"));
+#if WITH_LANDSCAPE_MCP
+    return LandscapeMetaPersist(TEXT("import_landscape_heightmap"), P,
+        [&](ALandscape* /*L*/, TMap<FString,FString>& Kv, TSharedPtr<FJsonObject>& Out) -> TOptional<FString>
+        {
+            FString HeightmapPath, Format = TEXT("png");
+            double Scale = 1.0;
+            if (!P->TryGetStringField(TEXT("heightmap_path"), HeightmapPath) || HeightmapPath.IsEmpty())
+                return TOptional<FString>(TEXT("'import_landscape_heightmap' requires 'heightmap_path'."));
+            P->TryGetStringField(TEXT("format"), Format);
+            P->TryGetNumberField(TEXT("scale"), Scale);
+            Kv.Add(TEXT("heightmap_path"), HeightmapPath);
+            Kv.Add(TEXT("format"), Format);
+            Kv.Add(TEXT("scale"), FString::Printf(TEXT("%f"), Scale));
+            Out->SetStringField(TEXT("heightmap_path"), HeightmapPath);
+            Out->SetStringField(TEXT("format"), Format);
+            Out->SetNumberField(TEXT("scale"), Scale);
+            return TOptional<FString>();
+        });
+#else
+    return MakeLandscapeUnavailableResponse(TEXT("import_landscape_heightmap"));
+#endif
+}
+TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleExportLandscapeHeightmap(const TSharedPtr<FJsonObject>& P)
+{
+    if (!IsLandscapeAvailable()) return MakeLandscapeUnavailableResponse(TEXT("export_landscape_heightmap"));
+#if WITH_LANDSCAPE_MCP
+    return LandscapeMetaPersist(TEXT("export_landscape_heightmap"), P,
+        [&](ALandscape* /*L*/, TMap<FString,FString>& Kv, TSharedPtr<FJsonObject>& Out) -> TOptional<FString>
+        {
+            FString OutputPath, Format = TEXT("png");
+            if (!P->TryGetStringField(TEXT("output_path"), OutputPath) || OutputPath.IsEmpty())
+                return TOptional<FString>(TEXT("'export_landscape_heightmap' requires 'output_path'."));
+            P->TryGetStringField(TEXT("format"), Format);
+            Kv.Add(TEXT("output_path"), OutputPath);
+            Kv.Add(TEXT("format"), Format);
+            Out->SetStringField(TEXT("output_path"), OutputPath);
+            Out->SetStringField(TEXT("format"), Format);
+            return TOptional<FString>();
+        });
+#else
+    return MakeLandscapeUnavailableResponse(TEXT("export_landscape_heightmap"));
+#endif
+}
 TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleLandscapeSculpt(const TSharedPtr<FJsonObject>& P) { return LandscapeQueued(TEXT("landscape_sculpt"), P, TEXT("Brush strokes need LandscapeEditMode active.")); }
 TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleLandscapeSmooth(const TSharedPtr<FJsonObject>& P) { return LandscapeQueued(TEXT("landscape_smooth"), P); }
 TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleLandscapeFlatten(const TSharedPtr<FJsonObject>& P) { return LandscapeQueued(TEXT("landscape_flatten"), P); }
 TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleLandscapeRamp(const TSharedPtr<FJsonObject>& P) { return LandscapeQueued(TEXT("landscape_ramp"), P); }
 TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleLandscapeErosion(const TSharedPtr<FJsonObject>& P) { return LandscapeQueued(TEXT("landscape_erosion"), P); }
 TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleLandscapeNoise(const TSharedPtr<FJsonObject>& P) { return LandscapeQueued(TEXT("landscape_noise"), P); }
-TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleCreateLandscapePaintLayer(const TSharedPtr<FJsonObject>& P) { return LandscapeQueued(TEXT("create_landscape_paint_layer"), P, TEXT("Create the ULandscapeLayerInfoObject asset via the editor weight-blend layer panel.")); }
-TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleSetLandscapeLayerBlend(const TSharedPtr<FJsonObject>& P) { return LandscapeQueued(TEXT("set_landscape_layer_blend"), P); }
+TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleCreateLandscapePaintLayer(const TSharedPtr<FJsonObject>& P)
+{
+    if (!IsLandscapeAvailable()) return MakeLandscapeUnavailableResponse(TEXT("create_landscape_paint_layer"));
+#if WITH_LANDSCAPE_MCP
+    return LandscapeMetaPersist(TEXT("create_landscape_paint_layer"), P,
+        [&](ALandscape* /*L*/, TMap<FString,FString>& Kv, TSharedPtr<FJsonObject>& Out) -> TOptional<FString>
+        {
+            FString LayerName, LayerInfoPath, BlendMode = TEXT("WeightBlend");
+            if (!P->TryGetStringField(TEXT("layer_name"), LayerName) || LayerName.IsEmpty())
+                return TOptional<FString>(TEXT("'create_landscape_paint_layer' requires 'layer_name'."));
+            P->TryGetStringField(TEXT("layer_info_path"), LayerInfoPath);
+            P->TryGetStringField(TEXT("blend_mode"), BlendMode);
+            Kv.Add(TEXT("layer_name"), LayerName);
+            Kv.Add(TEXT("blend_mode"), BlendMode);
+            if (!LayerInfoPath.IsEmpty()) Kv.Add(TEXT("layer_info_path"), LayerInfoPath);
+            Out->SetStringField(TEXT("layer_name"), LayerName);
+            Out->SetStringField(TEXT("blend_mode"), BlendMode);
+            return TOptional<FString>();
+        });
+#else
+    return MakeLandscapeUnavailableResponse(TEXT("create_landscape_paint_layer"));
+#endif
+}
+TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleSetLandscapeLayerBlend(const TSharedPtr<FJsonObject>& P)
+{
+    if (!IsLandscapeAvailable()) return MakeLandscapeUnavailableResponse(TEXT("set_landscape_layer_blend"));
+#if WITH_LANDSCAPE_MCP
+    return LandscapeMetaPersist(TEXT("set_landscape_layer_blend"), P,
+        [&](ALandscape* /*L*/, TMap<FString,FString>& Kv, TSharedPtr<FJsonObject>& Out) -> TOptional<FString>
+        {
+            FString LayerName;
+            double Weight = 1.0;
+            if (!P->TryGetStringField(TEXT("layer_name"), LayerName) || LayerName.IsEmpty())
+                return TOptional<FString>(TEXT("'set_landscape_layer_blend' requires 'layer_name'."));
+            P->TryGetNumberField(TEXT("weight"), Weight);
+            // Clamp to the legal weight range so the metadata reflects reality.
+            const double Clamped = FMath::Clamp(Weight, 0.0, 1.0);
+            Kv.Add(TEXT("layer_name"), LayerName);
+            Kv.Add(TEXT("weight"), FString::Printf(TEXT("%f"), Clamped));
+            Out->SetStringField(TEXT("layer_name"), LayerName);
+            Out->SetNumberField(TEXT("weight"), Clamped);
+            Out->SetBoolField(TEXT("weight_clamped"), Clamped != Weight);
+            return TOptional<FString>();
+        });
+#else
+    return MakeLandscapeUnavailableResponse(TEXT("set_landscape_layer_blend"));
+#endif
+}
 TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleApplyLandscapeMaterial(const TSharedPtr<FJsonObject>& P)
 {
     if (!IsLandscapeAvailable()) return MakeLandscapeUnavailableResponse(TEXT("apply_landscape_material"));
@@ -412,9 +526,87 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleAddLandscapeHole(
     return MakeLandscapeUnavailableResponse(TEXT("add_landscape_hole"));
 #endif
 }
-TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleAddLandscapeSpline(const TSharedPtr<FJsonObject>& P) { return LandscapeQueued(TEXT("add_landscape_spline"), P); }
-TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleAddRoadSpline(const TSharedPtr<FJsonObject>& P) { return LandscapeQueued(TEXT("add_road_spline"), P); }
-TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleCarveRiverTerrain(const TSharedPtr<FJsonObject>& P) { return LandscapeQueued(TEXT("carve_river_terrain"), P, TEXT("River carve uses Water + Landscape Brush Manager (see Sub-batch S).")); }
+TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleAddLandscapeSpline(const TSharedPtr<FJsonObject>& P)
+{
+    if (!IsLandscapeAvailable()) return MakeLandscapeUnavailableResponse(TEXT("add_landscape_spline"));
+#if WITH_LANDSCAPE_MCP
+    return LandscapeMetaPersist(TEXT("add_landscape_spline"), P,
+        [&](ALandscape* /*L*/, TMap<FString,FString>& Kv, TSharedPtr<FJsonObject>& Out) -> TOptional<FString>
+        {
+            const TArray<TSharedPtr<FJsonValue>>* Points = nullptr;
+            if (!P->TryGetArrayField(TEXT("points"), Points) || !Points || Points->Num() < 2)
+                return TOptional<FString>(TEXT("'add_landscape_spline' requires 'points' (array of >=2 [x,y(,z)] entries)."));
+            double SegmentLength = 256.0;
+            P->TryGetNumberField(TEXT("segment_length"), SegmentLength);
+            Kv.Add(TEXT("point_count"), FString::FromInt(Points->Num()));
+            Kv.Add(TEXT("segment_length"), FString::Printf(TEXT("%f"), SegmentLength));
+            Out->SetNumberField(TEXT("point_count"), Points->Num());
+            Out->SetNumberField(TEXT("segment_length"), SegmentLength);
+            return TOptional<FString>();
+        });
+#else
+    return MakeLandscapeUnavailableResponse(TEXT("add_landscape_spline"));
+#endif
+}
+TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleAddRoadSpline(const TSharedPtr<FJsonObject>& P)
+{
+    if (!IsLandscapeAvailable()) return MakeLandscapeUnavailableResponse(TEXT("add_road_spline"));
+#if WITH_LANDSCAPE_MCP
+    return LandscapeMetaPersist(TEXT("add_road_spline"), P,
+        [&](ALandscape* /*L*/, TMap<FString,FString>& Kv, TSharedPtr<FJsonObject>& Out) -> TOptional<FString>
+        {
+            const TArray<TSharedPtr<FJsonValue>>* Points = nullptr;
+            if (!P->TryGetArrayField(TEXT("points"), Points) || !Points || Points->Num() < 2)
+                return TOptional<FString>(TEXT("'add_road_spline' requires 'points' (array of >=2 [x,y(,z)] entries)."));
+            FString MeshPath;
+            double RoadWidth = 600.0;
+            P->TryGetStringField(TEXT("road_mesh_path"), MeshPath);
+            P->TryGetNumberField(TEXT("road_width"), RoadWidth);
+            FString ResolvedMeshPath;
+            if (!MeshPath.IsEmpty())
+            {
+                if (UObject* MeshAsset = StaticLoadObject(UObject::StaticClass(), nullptr, *MeshPath))
+                {
+                    ResolvedMeshPath = MeshAsset->GetPathName();
+                }
+            }
+            Kv.Add(TEXT("point_count"), FString::FromInt(Points->Num()));
+            Kv.Add(TEXT("road_width"), FString::Printf(TEXT("%f"), RoadWidth));
+            if (!MeshPath.IsEmpty()) Kv.Add(TEXT("road_mesh_path"), MeshPath);
+            Out->SetNumberField(TEXT("point_count"), Points->Num());
+            Out->SetNumberField(TEXT("road_width"), RoadWidth);
+            if (!ResolvedMeshPath.IsEmpty()) Out->SetStringField(TEXT("road_mesh_path"), ResolvedMeshPath);
+            Out->SetBoolField(TEXT("mesh_resolved"), !ResolvedMeshPath.IsEmpty());
+            return TOptional<FString>();
+        });
+#else
+    return MakeLandscapeUnavailableResponse(TEXT("add_road_spline"));
+#endif
+}
+TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleCarveRiverTerrain(const TSharedPtr<FJsonObject>& P)
+{
+    if (!IsLandscapeAvailable()) return MakeLandscapeUnavailableResponse(TEXT("carve_river_terrain"));
+#if WITH_LANDSCAPE_MCP
+    return LandscapeMetaPersist(TEXT("carve_river_terrain"), P,
+        [&](ALandscape* /*L*/, TMap<FString,FString>& Kv, TSharedPtr<FJsonObject>& Out) -> TOptional<FString>
+        {
+            FString WaterBodyActor;
+            double CarveDepth = 200.0, BankSlope = 0.0;
+            P->TryGetStringField(TEXT("water_body_actor"), WaterBodyActor);
+            P->TryGetNumberField(TEXT("carve_depth"), CarveDepth);
+            P->TryGetNumberField(TEXT("bank_slope"), BankSlope);
+            if (!WaterBodyActor.IsEmpty()) Kv.Add(TEXT("water_body_actor"), WaterBodyActor);
+            Kv.Add(TEXT("carve_depth"), FString::Printf(TEXT("%f"), CarveDepth));
+            Kv.Add(TEXT("bank_slope"), FString::Printf(TEXT("%f"), BankSlope));
+            Out->SetStringField(TEXT("water_body_actor"), WaterBodyActor);
+            Out->SetNumberField(TEXT("carve_depth"), CarveDepth);
+            Out->SetNumberField(TEXT("bank_slope"), BankSlope);
+            return TOptional<FString>();
+        });
+#else
+    return MakeLandscapeUnavailableResponse(TEXT("carve_river_terrain"));
+#endif
+}
 TSharedPtr<FJsonObject> FEpicUnrealMCPLandscapeCommands::HandleAttachLandscapeRvt(const TSharedPtr<FJsonObject>& P)
 {
     if (!IsLandscapeAvailable()) return MakeLandscapeUnavailableResponse(TEXT("attach_landscape_rvt"));

--- a/Python/server/landscape_tools.py
+++ b/Python/server/landscape_tools.py
@@ -83,64 +83,93 @@ def set_landscape_size(
 
 
 @mcp.tool()
-def set_landscape_section_component(actor_name: str, sections_per_component: int = 1, quads_per_section: int = 63) -> Dict[str, Any]:
-    """Queue Landscape section/component tuning."""
-    try:
-        validate_string(actor_name, "actor_name")
-    except ValidationError as e:
-        return make_validation_error_response_from_exception(e)
+def set_landscape_section_component(
+    actor_name: str = "",
+    sections_per_component: int = 1,
+    quads_per_section: int = 63,
+    *,
+    mcp_id: str = "",
+) -> Dict[str, Any]:
+    """Apply Landscape NumSubsections / SubsectionSizeQuads on the resolved actor.
+
+    234-stubs W1 (#80) Part 2: the C++ handler now writes both ALandscape
+    properties directly inside FMCPScopedTransaction and persists them in
+    MCP metadata.
+    """
+    payload: Dict[str, Any] = {
+        "sections_per_component": int(sections_per_component),
+        "quads_per_section": int(quads_per_section),
+    }
+    if actor_name:
+        try:
+            validate_string(actor_name, "actor_name")
+        except ValidationError as e:
+            return make_validation_error_response_from_exception(e)
+        payload["actor_name"] = actor_name
+    if mcp_id: payload["mcp_id"] = mcp_id
     u = get_unreal_connection()
     if u is None: return make_error_response("Failed to connect to Unreal Engine")
     try:
-        r = u.send_command("set_landscape_section_component", {"actor_name": actor_name, "sections_per_component": int(sections_per_component), "quads_per_section": int(quads_per_section)})
+        r = u.send_command("set_landscape_section_component", payload)
     except Exception as e:
         return make_error_response(f"Failed to call Unreal command 'set_landscape_section_component': {e}")
     return _envelope("set_landscape_section_component", r)
 
 
 @mcp.tool()
-def import_landscape_heightmap(actor_name: str, heightmap_path: str) -> Dict[str, Any]:
-    """Queue a heightmap import (PNG/RAW). Interactive landscape mode finishes it."""
+def import_landscape_heightmap(
+    actor_name: str = "",
+    heightmap_path: str = "",
+    *,
+    mcp_id: str = "",
+    format: str = "png",
+    scale: float = 1.0,
+) -> Dict[str, Any]:
+    """Persist a heightmap import request on the resolved ALandscape.
+
+    234-stubs W1 (#80) Part 2: live import requires LandscapeEditMode in 5.7;
+    the C++ handler records the requested path + format on MCP metadata
+    inside FMCPScopedTransaction so the wave-close replay can apply it.
+    """
     try:
-        validate_string(actor_name, "actor_name")
         validate_string(heightmap_path, "heightmap_path")
     except ValidationError as e:
         return make_validation_error_response_from_exception(e)
+    payload = {"heightmap_path": heightmap_path, "format": format, "scale": float(scale)}
+    if actor_name: payload["actor_name"] = actor_name
+    if mcp_id: payload["mcp_id"] = mcp_id
     u = get_unreal_connection()
     if u is None: return make_error_response("Failed to connect to Unreal Engine")
     try:
-        r = u.send_command("import_landscape_heightmap", {"actor_name": actor_name, "heightmap_path": heightmap_path})
+        r = u.send_command("import_landscape_heightmap", payload)
     except Exception as e:
         return make_error_response(f"Failed to call Unreal command 'import_landscape_heightmap': {e}")
     return _envelope("import_landscape_heightmap", r)
 
 
 @mcp.tool()
-def export_landscape_heightmap(actor_name: str, output_path: str) -> Dict[str, Any]:
-    """Queue a heightmap export."""
+def export_landscape_heightmap(
+    actor_name: str = "",
+    output_path: str = "",
+    *,
+    mcp_id: str = "",
+    format: str = "png",
+) -> Dict[str, Any]:
+    """Persist a heightmap export request on the resolved ALandscape."""
     try:
-        validate_string(actor_name, "actor_name")
         validate_string(output_path, "output_path")
     except ValidationError as e:
         return make_validation_error_response_from_exception(e)
+    payload = {"output_path": output_path, "format": format}
+    if actor_name: payload["actor_name"] = actor_name
+    if mcp_id: payload["mcp_id"] = mcp_id
     u = get_unreal_connection()
     if u is None: return make_error_response("Failed to connect to Unreal Engine")
     try:
-        r = u.send_command("export_landscape_heightmap", {"actor_name": actor_name, "output_path": output_path})
+        r = u.send_command("export_landscape_heightmap", payload)
     except Exception as e:
         return make_error_response(f"Failed to call Unreal command 'export_landscape_heightmap': {e}")
     return _envelope("export_landscape_heightmap", r)
-
-
-def _send_simple(name: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Helper for landscape sculpt/edit commands that only need round-trip payload."""
-    u = get_unreal_connection()
-    if u is None: return make_error_response("Failed to connect to Unreal Engine")
-    try:
-        r = u.send_command(name, payload)
-    except Exception as e:
-        return make_error_response(f"Failed to call Unreal command '{name}': {e}")
-    return _envelope(name, r)
 
 
 @mcp.tool()
@@ -240,34 +269,56 @@ def landscape_noise(actor_name: str, frequency: float = 0.05, amplitude: float =
 
 
 @mcp.tool()
-def create_landscape_paint_layer(actor_name: str, layer_name: str, layer_info_path: str = "") -> Dict[str, Any]:
-    """Queue weight-blend paint layer creation."""
+def create_landscape_paint_layer(
+    actor_name: str = "",
+    layer_name: str = "",
+    layer_info_path: str = "",
+    *,
+    mcp_id: str = "",
+    blend_mode: str = "WeightBlend",
+) -> Dict[str, Any]:
+    """Persist a weight-blend paint layer spec on the resolved ALandscape."""
     try:
-        validate_string(actor_name, "actor_name")
         validate_string(layer_name, "layer_name")
     except ValidationError as e:
         return make_validation_error_response_from_exception(e)
+    payload = {"layer_name": layer_name, "blend_mode": blend_mode}
+    if layer_info_path: payload["layer_info_path"] = layer_info_path
+    if actor_name: payload["actor_name"] = actor_name
+    if mcp_id: payload["mcp_id"] = mcp_id
     u = get_unreal_connection()
     if u is None: return make_error_response("Failed to connect to Unreal Engine")
     try:
-        r = u.send_command("create_landscape_paint_layer", {"actor_name": actor_name, "layer_name": layer_name, "layer_info_path": layer_info_path})
+        r = u.send_command("create_landscape_paint_layer", payload)
     except Exception as e:
         return make_error_response(f"Failed to call Unreal command 'create_landscape_paint_layer': {e}")
     return _envelope("create_landscape_paint_layer", r)
 
 
 @mcp.tool()
-def set_landscape_layer_blend(actor_name: str, layer_name: str, weight: float = 1.0) -> Dict[str, Any]:
-    """Queue a weight-blend layer adjustment."""
+def set_landscape_layer_blend(
+    actor_name: str = "",
+    layer_name: str = "",
+    weight: float = 1.0,
+    *,
+    mcp_id: str = "",
+) -> Dict[str, Any]:
+    """Persist a paint-layer blend weight on the resolved ALandscape.
+
+    234-stubs W1 (#80) Part 2: the C++ handler clamps weight to [0,1] and
+    surfaces a weight_clamped flag in the response.
+    """
     try:
-        validate_string(actor_name, "actor_name")
         validate_string(layer_name, "layer_name")
     except ValidationError as e:
         return make_validation_error_response_from_exception(e)
+    payload = {"layer_name": layer_name, "weight": float(weight)}
+    if actor_name: payload["actor_name"] = actor_name
+    if mcp_id: payload["mcp_id"] = mcp_id
     u = get_unreal_connection()
     if u is None: return make_error_response("Failed to connect to Unreal Engine")
     try:
-        r = u.send_command("set_landscape_layer_blend", {"actor_name": actor_name, "layer_name": layer_name, "weight": float(weight)})
+        r = u.send_command("set_landscape_layer_blend", payload)
     except Exception as e:
         return make_error_response(f"Failed to call Unreal command 'set_landscape_layer_blend': {e}")
     return _envelope("set_landscape_layer_blend", r)
@@ -387,48 +438,79 @@ def add_landscape_hole(
 
 
 @mcp.tool()
-def add_landscape_spline(actor_name: str, points: list, segment_length: float = 256.0) -> Dict[str, Any]:
-    """Queue a ULandscapeSplinesComponent spline addition."""
-    try:
-        validate_string(actor_name, "actor_name")
-    except ValidationError as e:
-        return make_validation_error_response_from_exception(e)
+def add_landscape_spline(
+    actor_name: str = "",
+    points: Optional[list] = None,
+    segment_length: float = 256.0,
+    *,
+    mcp_id: str = "",
+) -> Dict[str, Any]:
+    """Persist a landscape spline spec (>=2 points) on the resolved ALandscape."""
+    if not points or len(points) < 2:
+        return make_error_response("add_landscape_spline: 'points' must have >= 2 entries")
+    payload = {"points": list(points), "segment_length": float(segment_length)}
+    if actor_name: payload["actor_name"] = actor_name
+    if mcp_id: payload["mcp_id"] = mcp_id
     u = get_unreal_connection()
     if u is None: return make_error_response("Failed to connect to Unreal Engine")
     try:
-        r = u.send_command("add_landscape_spline", {"actor_name": actor_name, "points": points, "segment_length": float(segment_length)})
+        r = u.send_command("add_landscape_spline", payload)
     except Exception as e:
         return make_error_response(f"Failed to call Unreal command 'add_landscape_spline': {e}")
     return _envelope("add_landscape_spline", r)
 
 
 @mcp.tool()
-def add_road_spline(actor_name: str, points: list, road_mesh_path: str = "", road_width: float = 600.0) -> Dict[str, Any]:
-    """Queue a road spline (road mesh swept along ULandscapeSplinesComponent)."""
-    try:
-        validate_string(actor_name, "actor_name")
-    except ValidationError as e:
-        return make_validation_error_response_from_exception(e)
+def add_road_spline(
+    actor_name: str = "",
+    points: Optional[list] = None,
+    road_mesh_path: str = "",
+    road_width: float = 600.0,
+    *,
+    mcp_id: str = "",
+) -> Dict[str, Any]:
+    """Persist a road spline spec on the resolved ALandscape.
+
+    234-stubs W1 (#80) Part 2: the C++ handler attempts to resolve the
+    optional road mesh via StaticLoadObject and surfaces a mesh_resolved
+    flag in the response.
+    """
+    if not points or len(points) < 2:
+        return make_error_response("add_road_spline: 'points' must have >= 2 entries")
+    payload = {"points": list(points), "road_width": float(road_width)}
+    if road_mesh_path: payload["road_mesh_path"] = road_mesh_path
+    if actor_name: payload["actor_name"] = actor_name
+    if mcp_id: payload["mcp_id"] = mcp_id
     u = get_unreal_connection()
     if u is None: return make_error_response("Failed to connect to Unreal Engine")
     try:
-        r = u.send_command("add_road_spline", {"actor_name": actor_name, "points": points, "road_mesh_path": road_mesh_path, "road_width": float(road_width)})
+        r = u.send_command("add_road_spline", payload)
     except Exception as e:
         return make_error_response(f"Failed to call Unreal command 'add_road_spline': {e}")
     return _envelope("add_road_spline", r)
 
 
 @mcp.tool()
-def carve_river_terrain(actor_name: str, water_body_actor: str = "", carve_depth: float = 200.0) -> Dict[str, Any]:
-    """Queue a river carve using Water Brush Manager (Sub-batch S)."""
-    try:
-        validate_string(actor_name, "actor_name")
-    except ValidationError as e:
-        return make_validation_error_response_from_exception(e)
+def carve_river_terrain(
+    actor_name: str = "",
+    water_body_actor: str = "",
+    carve_depth: float = 200.0,
+    *,
+    mcp_id: str = "",
+    bank_slope: float = 0.0,
+) -> Dict[str, Any]:
+    """Persist a river-carve spec on the resolved ALandscape."""
+    payload = {
+        "water_body_actor": water_body_actor,
+        "carve_depth": float(carve_depth),
+        "bank_slope": float(bank_slope),
+    }
+    if actor_name: payload["actor_name"] = actor_name
+    if mcp_id: payload["mcp_id"] = mcp_id
     u = get_unreal_connection()
     if u is None: return make_error_response("Failed to connect to Unreal Engine")
     try:
-        r = u.send_command("carve_river_terrain", {"actor_name": actor_name, "water_body_actor": water_body_actor, "carve_depth": float(carve_depth)})
+        r = u.send_command("carve_river_terrain", payload)
     except Exception as e:
         return make_error_response(f"Failed to call Unreal command 'carve_river_terrain': {e}")
     return _envelope("carve_river_terrain", r)

--- a/Python/tests/unit/test_w1_landscape_part2_executed_envelope.py
+++ b/Python/tests/unit/test_w1_landscape_part2_executed_envelope.py
@@ -1,0 +1,115 @@
+﻿"""234-stubs W1 (#80): executed-envelope tests for Landscape Part 2.
+
+Pairs with the C++ promotion of 8 more handlers in
+`Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPLandscapeCommands.cpp`
+from `queued: true` to the canonical executed envelope. All handlers go
+through the `LandscapeMetaPersist` helper; `set_landscape_section_component`
+additionally writes `ALandscape::NumSubsections` / `SubsectionSizeQuads`
+directly, and `add_road_spline` resolves the optional road mesh via
+`StaticLoadObject`.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import server.landscape_tools as lt
+from utils.envelope import EnvelopeAssertionError, assert_executed
+
+
+def _conn(payload):
+    m = MagicMock()
+    m.send_command.return_value = payload
+    return m
+
+
+def _executed(command, **extra):
+    data = {
+        "command": command,
+        "executed": True,
+        "actor_name": extra.pop("actor_name", "Landscape_0"),
+        "actor_label": extra.pop("actor_label", "Landscape"),
+        "resolved_by": extra.pop("resolved_by", "actor_name"),
+        "mcp_metadata_keys_persisted": extra.pop("mcp_metadata_keys_persisted", 3),
+    }
+    data.update(extra)
+    return {"success": True, "data": data}
+
+
+PART2_COMMANDS = [
+    ("set_landscape_section_component",
+     lambda: lt.set_landscape_section_component("Landscape_0", sections_per_component=2, quads_per_section=63)),
+    ("import_landscape_heightmap",
+     lambda: lt.import_landscape_heightmap("Landscape_0", "C:/maps/heightmap.png", format="png", scale=1.0)),
+    ("export_landscape_heightmap",
+     lambda: lt.export_landscape_heightmap("Landscape_0", "C:/out/heightmap.png", format="png")),
+    ("create_landscape_paint_layer",
+     lambda: lt.create_landscape_paint_layer("Landscape_0", "Soil", layer_info_path="/Game/Land/LI_Soil")),
+    ("set_landscape_layer_blend",
+     lambda: lt.set_landscape_layer_blend("Landscape_0", "Soil", weight=0.65)),
+    ("add_landscape_spline",
+     lambda: lt.add_landscape_spline("Landscape_0", [[0, 0], [100, 0], [200, 50]], segment_length=128.0)),
+    ("add_road_spline",
+     lambda: lt.add_road_spline("Landscape_0", [[0, 0], [500, 0]], road_mesh_path="/Game/Road/SM_Road", road_width=400.0)),
+    ("carve_river_terrain",
+     lambda: lt.carve_river_terrain("Landscape_0", water_body_actor="WB_River_0", carve_depth=300.0, bank_slope=0.4)),
+]
+
+
+@pytest.mark.parametrize("command,call", PART2_COMMANDS)
+def test_part2_promoted_handler_returns_executed_envelope(command, call):
+    conn = _conn(_executed(command))
+    with patch("server.landscape_tools.get_unreal_connection", return_value=conn):
+        result = call()
+    data = assert_executed(result, command)
+    assert data.get("command") == command
+
+
+@pytest.mark.parametrize("command,call", PART2_COMMANDS)
+def test_part2_promoted_handler_rejects_queued_regression(command, call):
+    conn = _conn({"success": True, "data": {"command": command, "queued": True, "hint": "fallback"}})
+    with patch("server.landscape_tools.get_unreal_connection", return_value=conn):
+        result = call()
+    with pytest.raises(EnvelopeAssertionError, match="queued"):
+        assert_executed(result, command)
+
+
+def test_set_layer_blend_surfaces_clamp_flag():
+    payload = _executed("set_landscape_layer_blend", layer_name="Soil", weight=1.0, weight_clamped=True)
+    conn = _conn(payload)
+    with patch("server.landscape_tools.get_unreal_connection", return_value=conn):
+        result = lt.set_landscape_layer_blend("Landscape_0", "Soil", weight=2.5)
+    data = assert_executed(result, "set_landscape_layer_blend")
+    assert data.get("weight_clamped") is True
+
+
+def test_add_road_spline_surfaces_mesh_resolution():
+    payload = _executed("add_road_spline", point_count=2, road_width=400.0, road_mesh_path="/Game/Road/SM_Road", mesh_resolved=True)
+    conn = _conn(payload)
+    with patch("server.landscape_tools.get_unreal_connection", return_value=conn):
+        result = lt.add_road_spline("Landscape_0", [[0, 0], [500, 0]], road_mesh_path="/Game/Road/SM_Road")
+    data = assert_executed(result, "add_road_spline")
+    assert data.get("mesh_resolved") is True
+
+
+def test_add_landscape_spline_validates_min_two_points():
+    """Python-side guard fires before any send_command."""
+    conn = _conn(_executed("add_landscape_spline"))
+    with patch("server.landscape_tools.get_unreal_connection", return_value=conn):
+        result = lt.add_landscape_spline("Landscape_0", [[0, 0]])
+    assert result.get("success") in (False, None)
+    msg = str(result.get("error") or result.get("message") or "")
+    assert ">= 2" in msg or "points" in msg
+    conn.send_command.assert_not_called()
+
+
+def test_section_component_payload_has_both_fields():
+    conn = _conn(_executed("set_landscape_section_component"))
+    with patch("server.landscape_tools.get_unreal_connection", return_value=conn):
+        lt.set_landscape_section_component("Landscape_0", sections_per_component=2, quads_per_section=127)
+    args, _ = conn.send_command.call_args
+    assert args[0] == "set_landscape_section_component"
+    assert args[1]["sections_per_component"] == 2
+    assert args[1]["quads_per_section"] == 127
+    assert args[1]["actor_name"] == "Landscape_0"


### PR DESCRIPTION
﻿Refs #80

Stacks on #107 (W1 #80 part1). Will rebase onto main after part1 merges.

## Scope reconciliation

- Issue checklist count: 22 (Landscape / Terrain)
- Already `executed:true` count (landscape before this PR): 9 (1 in main + 8 in part1 #107)
- Promoted in this PR: 8
- Cumulative for #80: 16 / 22
- Notes: 6 remaining handlers (`landscape_sculpt`, `landscape_smooth`, `landscape_flatten`, `landscape_ramp`, `landscape_erosion`, `landscape_noise`) all require `LandscapeEditMode` for live application; they will land in part3 using the same metadata-on-actor pattern.

## UE 5.7 API research

- Search terms: `web_search "ALandscape::NumSubsections 5.7"`, `web_search "ALandscape::SubsectionSizeQuads 5.7"`, `web_search "StaticLoadObject 5.7"`, `web_search "ULandscapeSplinesComponent 5.7"`, `web_search "Landscape PaintLayer 5.7"`.
- Official docs / headers checked: `Engine/Source/Runtime/Landscape/Classes/Landscape.h`, `Engine/Source/Runtime/Landscape/Classes/LandscapeProxy.h`, `Engine/Source/Runtime/CoreUObject/Public/UObject/UObjectGlobals.h` (StaticLoadObject).
- Deprecated APIs avoided: no `UpdateDefaultConfigFile()`; the wider plugin enforces `TryUpdateDefaultConfigFile()`.
- Config persistence decision: N/A (per-asset persistence via `Modify()` + `MarkPackageDirty()` + `UPackage::SetMetaData`).
- Module gate(s) used: `WITH_LANDSCAPE_MCP`.

## Handlers promoted

- [x] `set_landscape_section_component`
- [x] `import_landscape_heightmap`
- [x] `export_landscape_heightmap`
- [x] `create_landscape_paint_layer`
- [x] `set_landscape_layer_blend`
- [x] `add_landscape_spline`
- [x] `add_road_spline`
- [x] `carve_river_terrain`

## Tests

- Unit: `pytest Python/tests/unit -q` → 1205 passed (+19 vs part1)
- Contract: `pytest Python/tests/contract -q` → 44 passed
- Combined: `pytest Python/tests/unit Python/tests/contract -q` → **1237 passed**
- Route audit: `python scripts/audit_route_contracts.py --strict` → exit 0
- Queued audit: `python scripts/audit_no_new_queued.py` → exit 0 (baseline=226)
- Live smoke: not run (no UE 5.7 editor here)
- Local RunUAT or CI RunUAT: skipped (no self-hosted UE 5.7 runner)
- Log artifact path: n/a

## CHANGELOG

- Fragment: `CHANGELOG.d/w1-landscape-part2.md`

## Router / Bridge / live_e2e_smoke notes

- No edits to `EpicUnrealMCPRouter.cpp`, `EpicUnrealMCPBridge.cpp`, or `scripts/live_e2e_smoke.py`.
