### PR TITLE
feat(234-stubs W1 #79 part3): promote final 4 Animation Rigging handlers (20/20) — closes #79

### DIFF
--- a/CHANGELOG.d/w1-anim-rigging-part3.md
+++ b/CHANGELOG.d/w1-anim-rigging-part3.md
@@ -1,0 +1,33 @@
+﻿### anim-rigging part3: final 4 handlers promoted (20/20 = #79 ready to close)
+
+- Issue: Closes #79
+- PR: codex-stubs-w1-anim-rigging-part3
+- Wave: W1
+- Handlers promoted in this PR: 4
+- Cumulative for #79: 20 / 20
+- New `executed: true` cases:
+  - `create_aim_offset` (factory + metadata fallback)
+  - `create_control_rig` (factory + metadata fallback)
+  - `sequencer_control_rig_track` (metadata on ULevelSequence)
+  - `connect_metahuman` (metadata on resolved host: USkeleton / USkeletalMesh / UBlueprint)
+
+Approach (UE 5.7-safe): reuses `TryCreateRuntimeResolvedAsset` and
+`AnimMetaFallback` from part2. For `create_control_rig`, the host
+resolution falls back to `host_asset_path` → `skeleton_path` →
+`skeletal_mesh_path` (first non-empty wins). `connect_metahuman` resolves
+its host asset by `host_asset_path` and surfaces a warning when
+`metahuman_id` is empty so the wave-close replay can branch.
+
+Python tool signatures extended to forward all C++-side fields while
+keeping the legacy positional signatures intact:
+- `connect_metahuman` accepts legacy `metahuman_blueprint_path` /
+  `target_actor` and forwards them as `metahuman_id` / `host_asset_path`
+  respectively (existing TestRetargeting test passes unchanged).
+- `sequencer_control_rig_track` validates `level_sequence_path` and
+  accepts `binding_guid` / `track_name`.
+- `create_control_rig` accepts `skeleton_path`, `skeletal_mesh_path`,
+  and `host_asset_path`.
+
+Tests: `Python/tests/unit/test_w1_anim_rigging_part3_executed_envelope.py`
+(12 cases: 4 parametrised executed assertions + 4 paired queued-regression
+guards + 2 mode-specific checks + 2 legacy-compat sanity).

--- a/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPAnimationRiggingCommands.cpp
+++ b/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPAnimationRiggingCommands.cpp
@@ -443,7 +443,53 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleCreateAnim
     return MakeRiggingUnavailableResponse(TEXT("create_anim_transition_rule"));
 #endif
 }
-TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleCreateAimOffset(const TSharedPtr<FJsonObject>& P) { return AnimQueued(TEXT("create_aim_offset"), P, TEXT("UAimOffsetBlendSpace asset factory is gated; payload accepted.")); }
+TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleCreateAimOffset(const TSharedPtr<FJsonObject>& P)
+{
+    if (!IsAnimRiggingAvailable()) return MakeRiggingUnavailableResponse(TEXT("create_aim_offset"));
+#if WITH_ANIM_RIGGING_MCP
+    if (!P.IsValid()) return AnimErr(TEXT("'create_aim_offset' requires JSON parameters."));
+    FString PackagePath = TEXT("/Game/Anim"), AssetName = TEXT("AO_New"), SkeletonPath;
+    P->TryGetStringField(TEXT("asset_path"), PackagePath);
+    P->TryGetStringField(TEXT("asset_name"), AssetName);
+    P->TryGetStringField(TEXT("skeleton_path"), SkeletonPath);
+
+    FString FactoryErr;
+    UObject* Asset = TryCreateRuntimeResolvedAsset(
+        TEXT("/Script/Engine.AimOffsetBlendSpace"),
+        TEXT("/Script/UnrealEd.AimOffsetBlendSpaceFactoryNew"),
+        PackagePath, AssetName, FactoryErr);
+    if (Asset)
+    {
+        if (!SkeletonPath.IsEmpty())
+        {
+            UPackage* Pkg = Asset->GetOutermost();
+            if (Pkg) Pkg->SetMetaData(*Asset, FName(TEXT("MCP.create_aim_offset.skeleton_path")), *SkeletonPath);
+        }
+        TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
+        Data->SetStringField(TEXT("command"), TEXT("create_aim_offset"));
+        Data->SetStringField(TEXT("asset_path"), Asset->GetPathName());
+        Data->SetStringField(TEXT("asset_name"), Asset->GetName());
+        Data->SetStringField(TEXT("mode"), TEXT("factory"));
+        Data->SetBoolField(TEXT("executed"), true);
+        return AnimOk(Data);
+    }
+
+    if (SkeletonPath.IsEmpty())
+    {
+        return AnimErr(
+            TEXT("'create_aim_offset': UAimOffsetBlendSpace factory unavailable and no 'skeleton_path' was provided for metadata fallback."),
+            FactoryErr);
+    }
+    return AnimMetaFallback(
+        TEXT("create_aim_offset"),
+        SkeletonPath,
+        TEXT("/Script/Engine.AimOffsetBlendSpace"),
+        AssetName, PackagePath, FactoryErr, P,
+        [&](UObject* /*Host*/, TMap<FString,FString>& /*Kv*/, TSharedPtr<FJsonObject>& /*Data*/){});
+#else
+    return MakeRiggingUnavailableResponse(TEXT("create_aim_offset"));
+#endif
+}
 TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleAddNotifyState(const TSharedPtr<FJsonObject>& P)
 {
     if (!IsAnimRiggingAvailable()) return MakeRiggingUnavailableResponse(TEXT("add_notify_state"));
@@ -672,7 +718,62 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleSetRetarge
     return MakeRiggingUnavailableResponse(TEXT("set_retarget_chain"));
 #endif
 }
-TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleCreateControlRig(const TSharedPtr<FJsonObject>& P) { return AnimQueued(TEXT("create_control_rig"), P, TEXT("UControlRigBlueprintFactory is gated by ControlRigEditor.")); }
+TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleCreateControlRig(const TSharedPtr<FJsonObject>& P)
+{
+    if (!IsAnimRiggingAvailable()) return MakeRiggingUnavailableResponse(TEXT("create_control_rig"));
+#if WITH_ANIM_RIGGING_MCP
+    if (!P.IsValid()) return AnimErr(TEXT("'create_control_rig' requires JSON parameters."));
+    FString PackagePath = TEXT("/Game/Rig"), AssetName = TEXT("CR_New");
+    FString SkeletonPath, SkeletalMeshPath, HostFallbackPath;
+    P->TryGetStringField(TEXT("asset_path"), PackagePath);
+    P->TryGetStringField(TEXT("asset_name"), AssetName);
+    P->TryGetStringField(TEXT("skeleton_path"), SkeletonPath);
+    P->TryGetStringField(TEXT("skeletal_mesh_path"), SkeletalMeshPath);
+    P->TryGetStringField(TEXT("host_asset_path"), HostFallbackPath);
+    if (HostFallbackPath.IsEmpty()) HostFallbackPath = SkeletonPath.IsEmpty() ? SkeletalMeshPath : SkeletonPath;
+
+    FString FactoryErr;
+    UObject* Asset = TryCreateRuntimeResolvedAsset(
+        TEXT("/Script/ControlRigDeveloper.ControlRigBlueprint"),
+        TEXT("/Script/ControlRigEditor.ControlRigBlueprintFactory"),
+        PackagePath, AssetName, FactoryErr);
+    if (Asset)
+    {
+        UPackage* Pkg = Asset->GetOutermost();
+        if (Pkg)
+        {
+            if (!SkeletonPath.IsEmpty()) Pkg->SetMetaData(*Asset, FName(TEXT("MCP.create_control_rig.skeleton_path")), *SkeletonPath);
+            if (!SkeletalMeshPath.IsEmpty()) Pkg->SetMetaData(*Asset, FName(TEXT("MCP.create_control_rig.skeletal_mesh_path")), *SkeletalMeshPath);
+        }
+        TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
+        Data->SetStringField(TEXT("command"), TEXT("create_control_rig"));
+        Data->SetStringField(TEXT("asset_path"), Asset->GetPathName());
+        Data->SetStringField(TEXT("asset_name"), Asset->GetName());
+        Data->SetStringField(TEXT("mode"), TEXT("factory"));
+        Data->SetBoolField(TEXT("executed"), true);
+        return AnimOk(Data);
+    }
+
+    if (HostFallbackPath.IsEmpty())
+    {
+        return AnimErr(
+            TEXT("'create_control_rig': UControlRigBlueprintFactory unavailable and no 'skeleton_path' / 'skeletal_mesh_path' / 'host_asset_path' provided for metadata fallback."),
+            FactoryErr);
+    }
+    return AnimMetaFallback(
+        TEXT("create_control_rig"),
+        HostFallbackPath,
+        TEXT("/Script/ControlRigDeveloper.ControlRigBlueprint"),
+        AssetName, PackagePath, FactoryErr, P,
+        [&](UObject* /*Host*/, TMap<FString,FString>& Kv, TSharedPtr<FJsonObject>& Data)
+        {
+            if (!SkeletonPath.IsEmpty()) { Kv.Add(TEXT("skeleton_path"), SkeletonPath); Data->SetStringField(TEXT("skeleton_path"), SkeletonPath); }
+            if (!SkeletalMeshPath.IsEmpty()) { Kv.Add(TEXT("skeletal_mesh_path"), SkeletalMeshPath); Data->SetStringField(TEXT("skeletal_mesh_path"), SkeletalMeshPath); }
+        });
+#else
+    return MakeRiggingUnavailableResponse(TEXT("create_control_rig"));
+#endif
+}
 TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleAddControlRigControl(const TSharedPtr<FJsonObject>& P)
 {
     if (!IsAnimRiggingAvailable()) return MakeRiggingUnavailableResponse(TEXT("add_control_rig_control"));
@@ -749,7 +850,34 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleSetControl
     return MakeRiggingUnavailableResponse(TEXT("set_control_rig_constraint"));
 #endif
 }
-TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleSequencerControlRigTrack(const TSharedPtr<FJsonObject>& P) { return AnimQueued(TEXT("sequencer_control_rig_track"), P, TEXT("Sequencer Control Rig track via UMovieSceneControlRigParameterTrack.")); }
+TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleSequencerControlRigTrack(const TSharedPtr<FJsonObject>& P)
+{
+    if (!IsAnimRiggingAvailable()) return MakeRiggingUnavailableResponse(TEXT("sequencer_control_rig_track"));
+#if WITH_ANIM_RIGGING_MCP
+    return AnimMetaPersist(
+        TEXT("sequencer_control_rig_track"),
+        TEXT("level_sequence_path"),
+        {TEXT("LevelSequence")},
+        P,
+        [&](UObject* /*Asset*/, TMap<FString,FString>& Kv, TSharedPtr<FJsonObject>& Data)
+        {
+            FString ControlRigPath, BindingGuid, TrackName = TEXT("ControlRigTrack");
+            if (!P->TryGetStringField(TEXT("control_rig_path"), ControlRigPath) || ControlRigPath.IsEmpty())
+            {
+                Data->SetStringField(TEXT("warning"), TEXT("control_rig_path was empty; the wave-close replay will skip the track."));
+            }
+            P->TryGetStringField(TEXT("binding_guid"), BindingGuid);
+            P->TryGetStringField(TEXT("track_name"), TrackName);
+            Kv.Add(TEXT("control_rig_path"), ControlRigPath);
+            if (!BindingGuid.IsEmpty()) Kv.Add(TEXT("binding_guid"), BindingGuid);
+            Kv.Add(TEXT("track_name"), TrackName);
+            Data->SetStringField(TEXT("control_rig_path"), ControlRigPath);
+            Data->SetStringField(TEXT("track_name"), TrackName);
+        });
+#else
+    return MakeRiggingUnavailableResponse(TEXT("sequencer_control_rig_track"));
+#endif
+}
 TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleSetFacialAnimation(const TSharedPtr<FJsonObject>& P)
 {
     if (!IsAnimRiggingAvailable()) return MakeRiggingUnavailableResponse(TEXT("set_facial_animation"));
@@ -835,4 +963,33 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleSetMorphTa
     return MakeRiggingUnavailableResponse(TEXT("set_morph_target"));
 #endif
 }
-TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleConnectMetaHuman(const TSharedPtr<FJsonObject>& P) { return AnimQueued(TEXT("connect_metahuman"), P, TEXT("MetaHuman Plugin integration is a separate optional dep.")); }
+TSharedPtr<FJsonObject> FEpicUnrealMCPAnimationRiggingCommands::HandleConnectMetaHuman(const TSharedPtr<FJsonObject>& P)
+{
+    if (!IsAnimRiggingAvailable()) return MakeRiggingUnavailableResponse(TEXT("connect_metahuman"));
+#if WITH_ANIM_RIGGING_MCP
+    return AnimMetaPersist(
+        TEXT("connect_metahuman"),
+        TEXT("host_asset_path"),
+        {TEXT("Skeleton"), TEXT("SkeletalMesh"), TEXT("Blueprint")},
+        P,
+        [&](UObject* /*Asset*/, TMap<FString,FString>& Kv, TSharedPtr<FJsonObject>& Data)
+        {
+            FString MetaHumanId, GroomPath, IdentityPath, FaceArchetype = TEXT("Default");
+            if (!P->TryGetStringField(TEXT("metahuman_id"), MetaHumanId) || MetaHumanId.IsEmpty())
+            {
+                Data->SetStringField(TEXT("warning"), TEXT("metahuman_id was empty; the wave-close replay will pick a default identity."));
+            }
+            P->TryGetStringField(TEXT("groom_path"), GroomPath);
+            P->TryGetStringField(TEXT("identity_path"), IdentityPath);
+            P->TryGetStringField(TEXT("face_archetype"), FaceArchetype);
+            Kv.Add(TEXT("metahuman_id"), MetaHumanId);
+            if (!GroomPath.IsEmpty()) Kv.Add(TEXT("groom_path"), GroomPath);
+            if (!IdentityPath.IsEmpty()) Kv.Add(TEXT("identity_path"), IdentityPath);
+            Kv.Add(TEXT("face_archetype"), FaceArchetype);
+            Data->SetStringField(TEXT("metahuman_id"), MetaHumanId);
+            Data->SetStringField(TEXT("face_archetype"), FaceArchetype);
+        });
+#else
+    return MakeRiggingUnavailableResponse(TEXT("connect_metahuman"));
+#endif
+}

--- a/Python/server/anim_rigging_tools.py
+++ b/Python/server/anim_rigging_tools.py
@@ -187,17 +187,26 @@ def create_anim_transition_rule(
 
 
 @mcp.tool()
-def create_aim_offset(asset_path: str = "/Game/Anim", asset_name: str = "AO_New", skeleton_path: str = "") -> Dict[str, Any]:
-    """Queue UAimOffsetBlendSpace asset creation."""
-    try:
-        pass
-    except ValidationError as e:
-        return make_validation_error_response_from_exception(e)
+def create_aim_offset(
+    asset_path: str = "/Game/Anim",
+    asset_name: str = "AO_New",
+    skeleton_path: str = "",
+) -> Dict[str, Any]:
+    """Create a UAimOffsetBlendSpace asset, or fall back to metadata.
+
+    234-stubs W1 (#79) Part 3: the C++ handler uses the runtime-resolved
+    factory (UAimOffsetBlendSpaceFactoryNew). If unavailable, it falls
+    back to AnimMetaFallback on `skeleton_path`.
+    """
     u = get_unreal_connection()
     if u is None:
         return make_error_response("Failed to connect to Unreal Engine")
     try:
-        r = u.send_command("create_aim_offset", {"asset_path": asset_path, "asset_name": asset_name, "skeleton_path": skeleton_path})
+        r = u.send_command("create_aim_offset", {
+            "asset_path": asset_path,
+            "asset_name": asset_name,
+            "skeleton_path": skeleton_path,
+        })
     except Exception as e:
         return make_error_response(f"Failed to call Unreal command 'create_aim_offset': {e}")
     return _envelope("create_aim_offset", r)
@@ -398,17 +407,32 @@ def set_retarget_chain(ik_rig_path: str, chain_name: str, start_bone: str, end_b
 
 
 @mcp.tool()
-def create_control_rig(asset_path: str = "/Game/Anim", asset_name: str = "CR_New", skeleton_path: str = "") -> Dict[str, Any]:
-    """Queue Control Rig blueprint creation."""
-    try:
-        pass
-    except ValidationError as e:
-        return make_validation_error_response_from_exception(e)
+def create_control_rig(
+    asset_path: str = "/Game/Anim",
+    asset_name: str = "CR_New",
+    skeleton_path: str = "",
+    skeletal_mesh_path: str = "",
+    host_asset_path: str = "",
+) -> Dict[str, Any]:
+    """Create a UControlRigBlueprint asset, or fall back to metadata.
+
+    234-stubs W1 (#79) Part 3: the C++ handler uses the runtime-resolved
+    factory (ControlRigBlueprintFactory in ControlRigEditor). If
+    unavailable, it falls back to AnimMetaFallback on host_asset_path,
+    skeleton_path, or skeletal_mesh_path (first non-empty wins).
+    """
     u = get_unreal_connection()
     if u is None:
         return make_error_response("Failed to connect to Unreal Engine")
+    payload = {
+        "asset_path": asset_path,
+        "asset_name": asset_name,
+    }
+    if skeleton_path: payload["skeleton_path"] = skeleton_path
+    if skeletal_mesh_path: payload["skeletal_mesh_path"] = skeletal_mesh_path
+    if host_asset_path: payload["host_asset_path"] = host_asset_path
     try:
-        r = u.send_command("create_control_rig", {"asset_path": asset_path, "asset_name": asset_name, "skeleton_path": skeleton_path})
+        r = u.send_command("create_control_rig", payload)
     except Exception as e:
         return make_error_response(f"Failed to call Unreal command 'create_control_rig': {e}")
     return _envelope("create_control_rig", r)
@@ -482,19 +506,35 @@ def set_control_rig_constraint(
 
 
 @mcp.tool()
-def sequencer_control_rig_track(level_sequence_path: str, skeletal_actor: str, control_rig_path: str) -> Dict[str, Any]:
-    """Queue Sequencer Control Rig track binding."""
+def sequencer_control_rig_track(
+    level_sequence_path: str,
+    skeletal_actor: str = "",
+    control_rig_path: str = "",
+    binding_guid: str = "",
+    track_name: str = "ControlRigTrack",
+) -> Dict[str, Any]:
+    """Persist a Sequencer Control Rig track spec on the ULevelSequence.
+
+    234-stubs W1 (#79) Part 3: now executed via the C++ AnimMetaPersist
+    helper (LevelSequence host). The Sequencer-side replay is in a
+    follow-up PR.
+    """
     try:
         validate_string(level_sequence_path, "level_sequence_path")
-        validate_string(skeletal_actor, "skeletal_actor")
-        validate_string(control_rig_path, "control_rig_path")
     except ValidationError as e:
         return make_validation_error_response_from_exception(e)
     u = get_unreal_connection()
     if u is None:
         return make_error_response("Failed to connect to Unreal Engine")
+    payload = {
+        "level_sequence_path": level_sequence_path,
+        "track_name": track_name,
+    }
+    if skeletal_actor: payload["skeletal_actor"] = skeletal_actor
+    if control_rig_path: payload["control_rig_path"] = control_rig_path
+    if binding_guid: payload["binding_guid"] = binding_guid
     try:
-        r = u.send_command("sequencer_control_rig_track", {"level_sequence_path": level_sequence_path, "skeletal_actor": skeletal_actor, "control_rig_path": control_rig_path})
+        r = u.send_command("sequencer_control_rig_track", payload)
     except Exception as e:
         return make_error_response(f"Failed to call Unreal command 'sequencer_control_rig_track': {e}")
     return _envelope("sequencer_control_rig_track", r)
@@ -557,17 +597,42 @@ def set_morph_target(skeletal_mesh_path: str, morph_target: str, weight: float =
 
 
 @mcp.tool()
-def connect_metahuman(metahuman_blueprint_path: str, target_actor: str = "") -> Dict[str, Any]:
-    """Queue MetaHuman blueprint connection."""
-    try:
-        validate_string(metahuman_blueprint_path, "metahuman_blueprint_path")
-    except ValidationError as e:
-        return make_validation_error_response_from_exception(e)
+def connect_metahuman(
+    metahuman_blueprint_path: str = "",
+    target_actor: str = "",
+    host_asset_path: str = "",
+    groom_path: str = "",
+    identity_path: str = "",
+    face_archetype: str = "Default",
+    metahuman_id: str = "",
+) -> Dict[str, Any]:
+    """Persist a MetaHuman wiring spec onto the resolved host asset.
+
+    234-stubs W1 (#79) Part 3: now executed via AnimMetaPersist. Legacy
+    callers can pass `metahuman_blueprint_path` and it will be forwarded as
+    `metahuman_id`. `host_asset_path` is required by the C++ side and
+    defaults to the legacy `target_actor` if not given.
+    """
+    effective_host = host_asset_path or target_actor
+    effective_id = metahuman_id or metahuman_blueprint_path
+    if not effective_host:
+        return make_error_response("connect_metahuman: host_asset_path (or legacy target_actor) is required")
     u = get_unreal_connection()
     if u is None:
         return make_error_response("Failed to connect to Unreal Engine")
+    payload = {
+        "host_asset_path": effective_host,
+        "metahuman_id": effective_id,
+        "face_archetype": face_archetype,
+    }
+    if groom_path: payload["groom_path"] = groom_path
+    if identity_path: payload["identity_path"] = identity_path
+    if metahuman_blueprint_path: payload["metahuman_blueprint_path"] = metahuman_blueprint_path
+    if target_actor: payload["target_actor"] = target_actor
     try:
-        r = u.send_command("connect_metahuman", {"metahuman_blueprint_path": metahuman_blueprint_path, "target_actor": target_actor})
+        r = u.send_command("connect_metahuman", payload)
     except Exception as e:
         return make_error_response(f"Failed to call Unreal command 'connect_metahuman': {e}")
     return _envelope("connect_metahuman", r)
+
+

--- a/Python/tests/unit/test_w1_anim_rigging_part3_executed_envelope.py
+++ b/Python/tests/unit/test_w1_anim_rigging_part3_executed_envelope.py
@@ -1,0 +1,107 @@
+﻿"""234-stubs W1 (#79): executed-envelope tests for Animation/Rigging Part 3.
+
+Closes #79 in tandem with the C++ promotion of the last 4 handlers in
+`Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPAnimationRiggingCommands.cpp`.
+After this PR every handler in the Animation Rigging category returns
+`executed: true`; only the helper definitions of `AnimQueued` / `AnimOk`
+keep the `queued: true` literal in source so the wave-close PR can drop
+the baseline.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import server.anim_rigging_tools as art
+from utils.envelope import EnvelopeAssertionError, assert_executed
+
+
+def _conn(payload):
+    m = MagicMock()
+    m.send_command.return_value = payload
+    return m
+
+
+def _executed(command, **extra):
+    data = {"command": command, "executed": True}
+    data.update(extra)
+    return {"success": True, "data": data}
+
+
+PART3_COMMANDS = [
+    ("create_aim_offset",
+     lambda: art.create_aim_offset(skeleton_path="/Game/Char/SK_Hero_Skeleton")),
+    ("create_control_rig",
+     lambda: art.create_control_rig(skeleton_path="/Game/Char/SK_Hero_Skeleton", skeletal_mesh_path="/Game/Char/SK_Hero")),
+    ("sequencer_control_rig_track",
+     lambda: art.sequencer_control_rig_track("/Game/Cine/LS_Hero", control_rig_path="/Game/Rig/CR_Hero", track_name="HeroRig")),
+    ("connect_metahuman",
+     lambda: art.connect_metahuman(host_asset_path="/Game/Char/SK_Hero_Skeleton", metahuman_id="hero_v1", face_archetype="MetaHuman")),
+]
+
+
+@pytest.mark.parametrize("command,call", PART3_COMMANDS)
+def test_part3_promoted_handler_returns_executed_envelope(command, call):
+    conn = _conn(_executed(command, asset_path="/Game/X/Y", mode="metadata_fallback", mcp_metadata_keys_persisted=4))
+    with patch("server.anim_rigging_tools.get_unreal_connection", return_value=conn):
+        result = call()
+    data = assert_executed(result, command)
+    assert data.get("command") == command
+
+
+@pytest.mark.parametrize("command,call", PART3_COMMANDS)
+def test_part3_promoted_handler_rejects_queued_regression(command, call):
+    queued = {"success": True, "data": {"command": command, "queued": True, "hint": "fallback"}}
+    conn = _conn(queued)
+    with patch("server.anim_rigging_tools.get_unreal_connection", return_value=conn):
+        result = call()
+    with pytest.raises(EnvelopeAssertionError, match="queued"):
+        assert_executed(result, command)
+
+
+def test_create_aim_offset_factory_mode_executed():
+    payload = _executed("create_aim_offset", asset_path="/Game/Anim/AO_Hero", asset_name="AO_Hero", mode="factory")
+    conn = _conn(payload)
+    with patch("server.anim_rigging_tools.get_unreal_connection", return_value=conn):
+        result = art.create_aim_offset(asset_name="AO_Hero", skeleton_path="/Game/Char/SK_Hero_Skeleton")
+    data = assert_executed(result, "create_aim_offset")
+    assert data.get("mode") == "factory"
+
+
+def test_create_control_rig_metadata_fallback_executed():
+    payload = _executed("create_control_rig",
+                       host_asset_path="/Game/Char/SK_Hero_Skeleton",
+                       wanted_class="/Script/ControlRigDeveloper.ControlRigBlueprint",
+                       wanted_asset_name="CR_Hero",
+                       wanted_package_path="/Game/Rig",
+                       factory_unavailable_reason="ControlRigEditor module not loaded",
+                       mode="metadata_fallback")
+    conn = _conn(payload)
+    with patch("server.anim_rigging_tools.get_unreal_connection", return_value=conn):
+        result = art.create_control_rig(asset_path="/Game/Rig", asset_name="CR_Hero", skeleton_path="/Game/Char/SK_Hero_Skeleton")
+    data = assert_executed(result, "create_control_rig")
+    assert data.get("mode") == "metadata_fallback"
+    assert data.get("host_asset_path") == "/Game/Char/SK_Hero_Skeleton"
+
+
+def test_connect_metahuman_legacy_positional_call_works():
+    """Legacy callers passing (metahuman_blueprint_path, target_actor=...) must keep working."""
+    conn = _conn(_executed("connect_metahuman"))
+    with patch("server.anim_rigging_tools.get_unreal_connection", return_value=conn):
+        result = art.connect_metahuman("/Game/MH_BP", target_actor="MyMetahuman")
+    args, _ = conn.send_command.call_args
+    assert args[0] == "connect_metahuman"
+    payload = args[1]
+    assert payload["host_asset_path"] == "MyMetahuman"
+    assert payload["metahuman_id"] == "/Game/MH_BP"
+    assert payload["metahuman_blueprint_path"] == "/Game/MH_BP"
+    assert payload["target_actor"] == "MyMetahuman"
+
+
+def test_sequencer_control_rig_track_validates_level_sequence_path():
+    conn = _conn(_executed("sequencer_control_rig_track"))
+    with patch("server.anim_rigging_tools.get_unreal_connection", return_value=conn):
+        result = art.sequencer_control_rig_track("")  # empty path must fail validation
+    assert result.get("success") in (False, None)
+    conn.send_command.assert_not_called()


### PR DESCRIPTION
﻿Closes #79

Stacks on #108 (W1 #79 part2). Final part for Animation Rigging — after this PR, all 20 handlers in #79 return `executed: true`.

## Scope reconciliation

- Issue checklist count: 20 (Animation Rigging)
- Already `executed:true` count (anim-rigging before this PR): 16 (2 in main + 8 in part1 + 8 in part2)
- Promoted in this PR: 4
- Cumulative for #79: **20 / 20**
- Notes: `AnimQueued` / `AnimOk` helper *definitions* still hold the `queued: true` literal so `audit_no_new_queued.py` baseline stays at 226 until the wave-close PR drops it.

## UE 5.7 API research

- Search terms: `web_search "UAimOffsetBlendSpace 5.7"`, `web_search "ControlRigBlueprintFactory 5.7"`, `web_search "MovieSceneControlRigParameterTrack 5.7"`, `web_search "MetaHuman plugin 5.7 anim wiring"`.
- Official docs / headers checked: `Engine/Source/Runtime/Engine/Classes/Animation/AimOffsetBlendSpace.h`, `Engine/Plugins/Animation/ControlRig/Source/ControlRigDeveloper/Public/ControlRigBlueprint.h`, `Engine/Plugins/MovieScene/Sequencer/Source/Sequencer/Public/MovieScene*`, `Engine/Plugins/MetaHuman/...`.
- Deprecated APIs avoided: no `UpdateDefaultConfigFile()`. ControlRigBlueprintFactory + AimOffsetBlendSpaceFactoryNew are resolved at *runtime* via `FindObject<UClass>` so the bridge stays buildable when those editor modules are absent.
- Config persistence decision: N/A (per-asset persistence via `Modify()` + `MarkPackageDirty()` + `UPackage::SetMetaData`).
- Module gate(s) used: `WITH_ANIM_RIGGING_MCP`.

## Handlers promoted

- [x] `create_aim_offset`
- [x] `create_control_rig`
- [x] `sequencer_control_rig_track`
- [x] `connect_metahuman`

## Tests

- Unit: `pytest Python/tests/unit -q` → 1212 passed (+12 vs part2)
- Contract: `pytest Python/tests/contract -q` → 44 passed
- Combined: `pytest Python/tests/unit Python/tests/contract -q` → **1244 passed**
- Route audit: `python scripts/audit_route_contracts.py --strict` → exit 0
- Queued audit: `python scripts/audit_no_new_queued.py` → exit 0 (baseline=226)
- Live smoke: not run (no UE 5.7 editor here)
- Local RunUAT or CI RunUAT: skipped (no self-hosted UE 5.7 runner)
- Log artifact path: n/a

## CHANGELOG

- Fragment: `CHANGELOG.d/w1-anim-rigging-part3.md`

## Router / Bridge / live_e2e_smoke notes

- No edits to `EpicUnrealMCPRouter.cpp`, `EpicUnrealMCPBridge.cpp`, or `scripts/live_e2e_smoke.py`.
