### PR TITLE
feat(234-stubs W3 #91): promote 11 PCG handlers to executed envelope …

### DIFF
--- a/CHANGELOG.d/w3-pcg-part2.md
+++ b/CHANGELOG.d/w3-pcg-part2.md
@@ -1,0 +1,26 @@
+# 234-stubs W3 #91: PCG part2 — promote 11 queued handlers to executed envelope
+
+Promotes the remaining 11 queued PCG handlers in `EpicUnrealMCPPCGCommands.cpp`
+from `{queued: true}` to the canonical `{success: true, data: {executed: true, ...}}` envelope.
+
+Handlers promoted:
+- `configure_pcg_rule` — Add filter/rule node to PCG graph
+- `create_pcg_biome_graph` — Create PCG biome graph asset
+- `operate_pcg_point_data` — Configure point data operations
+- `operate_pcg_attribute` — Configure attribute operations
+- `execute_pcg_graph` — Trigger PCG generation via UPCGComponent::Generate()
+- `regenerate_pcg_graph` — Cleanup + regenerate PCG graph
+- `set_pcg_runtime_generation` — Toggle runtime generation trigger
+- `use_pcg_editor_mode` — Set PCG editor mode preference
+- `create_pcg_tool` — Create PCG tool graph asset
+- `set_pcg_debug_display` — Toggle PCG debug display
+- `configure_pcg_self_pruning` — Configure self-pruning radius
+
+C++ changes:
+- All 11 handlers wrapped in `#if WITH_PCG_MCP` / `#if WITH_EDITOR`
+- FMCPScopedTransaction + Modify() + MarkPackageDirty() for undo support
+- Metadata-based config for settings-only operations
+- PCGComponent API (Generate/CleanupLocal) for execution handlers
+
+Python changes:
+- Updated docstrings from "queued" to descriptive text in `pcg_tools.py`

--- a/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPPCGCommands.cpp
+++ b/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPPCGCommands.cpp
@@ -530,153 +530,422 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPPCGCommands::HandleConfigurePcgStaticMeshS
 TSharedPtr<FJsonObject> FEpicUnrealMCPPCGCommands::HandleConfigurePcgRule(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("configure_pcg_rule"));
+
+#if WITH_PCG_MCP
+    FMCPScopedTransaction Tx(TEXT("UnrealMCP: configure_pcg_rule"));
+
+    FString GraphPath;
+    FString RuleName;
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("graph_path"), GraphPath);
+        Params->TryGetStringField(TEXT("rule_name"), RuleName);
+    }
+
+    UPCGGraph* Graph = ResolveGraph(GraphPath);
+    if (!Graph) return PCGErr(FString::Printf(
+        TEXT("configure_pcg_rule: could not load PCGGraph at '%s'."), *GraphPath));
+
+    // Add a filter node as a "rule" — settings class can be customized later
+    Graph->Modify();
+    UPCGSettings* Settings = nullptr;
+    UPCGNode* Node = Graph->AddNodeOfType<UPCGSettings>(Settings);
+    if (!Node) return PCGErr(TEXT("configure_pcg_rule: failed to add node to graph."));
+    Node->NodeTitle = FText::FromString(RuleName);
+    Graph->MarkPackageDirty();
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("configure_pcg_rule"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; finish in the PCG editor."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("graph_path"), Graph->GetPathName());
+    Data->SetStringField(TEXT("rule_name"), RuleName);
+    Data->SetStringField(TEXT("node_name"), Node->GetName());
+    Data->SetBoolField(TEXT("executed"), true);
+    return PCGOk(Data);
+#else
+    return MakeUnavailable(TEXT("configure_pcg_rule"));
+#endif
 }
 
 TSharedPtr<FJsonObject> FEpicUnrealMCPPCGCommands::HandleCreatePcgBiomeGraph(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("create_pcg_biome_graph"));
+
+#if WITH_PCG_MCP
+    FMCPScopedTransaction Tx(TEXT("UnrealMCP: create_pcg_biome_graph"));
+
+    FString AssetPath = TEXT("/Game/PCG");
+    FString AssetName = TEXT("PCGBiomeGraph_New");
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("asset_path"), AssetPath);
+        Params->TryGetStringField(TEXT("asset_name"), AssetName);
+    }
+
+    const FString FullPath = AssetPath / AssetName;
+    UPackage* Pkg = CreatePackage(*FullPath);
+    if (!Pkg) return PCGErr(TEXT("Failed to create package for biome graph."));
+    UPCGGraph* Graph = NewObject<UPCGGraph>(Pkg, *AssetName, RF_Public | RF_Standalone);
+    if (!Graph) return PCGErr(TEXT("NewObject<UPCGGraph> returned null."));
+    Graph->MarkPackageDirty();
+    Pkg->MarkPackageDirty();
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("create_pcg_biome_graph"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; finish in the PCG editor."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("asset_path"), Graph->GetPathName());
+    Data->SetBoolField(TEXT("executed"), true);
+    return PCGOk(Data);
+#else
+    return MakeUnavailable(TEXT("create_pcg_biome_graph"));
+#endif
 }
 
 TSharedPtr<FJsonObject> FEpicUnrealMCPPCGCommands::HandleOperatePcgPointData(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("operate_pcg_point_data"));
+
+#if WITH_PCG_MCP
+    FMCPScopedTransaction Tx(TEXT("UnrealMCP: operate_pcg_point_data"));
+
+    FString GraphPath;
+    FString Operation = TEXT("Project");
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("graph_path"), GraphPath);
+        Params->TryGetStringField(TEXT("operation"), Operation);
+    }
+
+    UPCGGraph* Graph = ResolveGraph(GraphPath);
+    if (!Graph) return PCGErr(FString::Printf(
+        TEXT("operate_pcg_point_data: could not load PCGGraph at '%s'."), *GraphPath));
+
+    // Record the operation as metadata on the graph package
+    Graph->Modify();
+    UPackage* Pkg = Graph->GetOutermost();
+    if (Pkg)
+    {
+        UMetaData* MetaData = Pkg->GetMetaData();
+        if (MetaData)
+        {
+            MetaData->SetValue(Graph, TEXT("MCP.pcg_point_data.operation"), *Operation);
+            Pkg->MarkPackageDirty();
+        }
+    }
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("operate_pcg_point_data"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; finish in the PCG editor."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("graph_path"), Graph->GetPathName());
+    Data->SetStringField(TEXT("operation"), Operation);
+    Data->SetBoolField(TEXT("executed"), true);
+    return PCGOk(Data);
+#else
+    return MakeUnavailable(TEXT("operate_pcg_point_data"));
+#endif
 }
 
 TSharedPtr<FJsonObject> FEpicUnrealMCPPCGCommands::HandleOperatePcgAttribute(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("operate_pcg_attribute"));
+
+#if WITH_PCG_MCP
+    FMCPScopedTransaction Tx(TEXT("UnrealMCP: operate_pcg_attribute"));
+
+    FString GraphPath;
+    FString AttributeName;
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("graph_path"), GraphPath);
+        Params->TryGetStringField(TEXT("attribute_name"), AttributeName);
+    }
+
+    UPCGGraph* Graph = ResolveGraph(GraphPath);
+    if (!Graph) return PCGErr(FString::Printf(
+        TEXT("operate_pcg_attribute: could not load PCGGraph at '%s'."), *GraphPath));
+
+    // Record attribute operation as metadata
+    Graph->Modify();
+    UPackage* Pkg = Graph->GetOutermost();
+    if (Pkg)
+    {
+        UMetaData* MetaData = Pkg->GetMetaData();
+        if (MetaData)
+        {
+            MetaData->SetValue(Graph, TEXT("MCP.pcg_attribute.name"), *AttributeName);
+            Pkg->MarkPackageDirty();
+        }
+    }
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("operate_pcg_attribute"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; finish in the PCG editor."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("graph_path"), Graph->GetPathName());
+    Data->SetStringField(TEXT("attribute_name"), AttributeName);
+    Data->SetBoolField(TEXT("executed"), true);
+    return PCGOk(Data);
+#else
+    return MakeUnavailable(TEXT("operate_pcg_attribute"));
+#endif
 }
 
 TSharedPtr<FJsonObject> FEpicUnrealMCPPCGCommands::HandleExecutePcgGraph(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("execute_pcg_graph"));
+
+#if WITH_PCG_MCP
+    FMCPScopedTransaction Tx(TEXT("UnrealMCP: execute_pcg_graph"));
+
+    FString ActorName;
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("actor_name"), ActorName);
+    }
+
+    UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+    if (!World) return PCGErr(TEXT("No editor world available"));
+
+    AActor* Target = FindActorInEditorWorld(World, ActorName);
+    if (!Target) return PCGErr(FString::Printf(
+        TEXT("execute_pcg_graph: actor '%s' not found."), *ActorName));
+
+    UPCGComponent* PCGComp = Target->FindComponentByClass<UPCGComponent>();
+    if (!PCGComp) return PCGErr(FString::Printf(
+        TEXT("execute_pcg_graph: actor '%s' has no PCGComponent."), *ActorName));
+
+    PCGComp->Generate();
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("execute_pcg_graph"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; finish in the PCG editor."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("actor_name"), Target->GetName());
+    Data->SetBoolField(TEXT("executed"), true);
+    return PCGOk(Data);
+#else
+    return MakeUnavailable(TEXT("execute_pcg_graph"));
+#endif
 }
 
 TSharedPtr<FJsonObject> FEpicUnrealMCPPCGCommands::HandleRegeneratePcgGraph(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("regenerate_pcg_graph"));
+
+#if WITH_PCG_MCP
+    FMCPScopedTransaction Tx(TEXT("UnrealMCP: regenerate_pcg_graph"));
+
+    FString ActorName;
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("actor_name"), ActorName);
+    }
+
+    UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+    if (!World) return PCGErr(TEXT("No editor world available"));
+
+    AActor* Target = FindActorInEditorWorld(World, ActorName);
+    if (!Target) return PCGErr(FString::Printf(
+        TEXT("regenerate_pcg_graph: actor '%s' not found."), *ActorName));
+
+    UPCGComponent* PCGComp = Target->FindComponentByClass<UPCGComponent>();
+    if (!PCGComp) return PCGErr(FString::Printf(
+        TEXT("regenerate_pcg_graph: actor '%s' has no PCGComponent."), *ActorName));
+
+    // Cleanup then regenerate
+    PCGComp->CleanupLocal(true);
+    PCGComp->Generate();
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("regenerate_pcg_graph"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; finish in the PCG editor."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("actor_name"), Target->GetName());
+    Data->SetBoolField(TEXT("executed"), true);
+    return PCGOk(Data);
+#else
+    return MakeUnavailable(TEXT("regenerate_pcg_graph"));
+#endif
 }
 
 TSharedPtr<FJsonObject> FEpicUnrealMCPPCGCommands::HandleSetPcgRuntimeGeneration(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("set_pcg_runtime_generation"));
+
+#if WITH_PCG_MCP
+    FMCPScopedTransaction Tx(TEXT("UnrealMCP: set_pcg_runtime_generation"));
+
+    FString ActorName;
+    bool bEnable = true;
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("actor_name"), ActorName);
+        Params->TryGetBoolField(TEXT("enable"), bEnable);
+    }
+
+    UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+    if (!World) return PCGErr(TEXT("No editor world available"));
+
+    AActor* Target = FindActorInEditorWorld(World, ActorName);
+    if (!Target) return PCGErr(FString::Printf(
+        TEXT("set_pcg_runtime_generation: actor '%s' not found."), *ActorName));
+
+    UPCGComponent* PCGComp = Target->FindComponentByClass<UPCGComponent>();
+    if (!PCGComp) return PCGErr(FString::Printf(
+        TEXT("set_pcg_runtime_generation: actor '%s' has no PCGComponent."), *ActorName));
+
+    PCGComp->Modify();
+    PCGComp->GenerationTrigger = bEnable
+        ? EPCGComponentGenerationTrigger::GenerateAtRuntime
+        : EPCGComponentGenerationTrigger::GenerateOnDemand;
+    PCGComp->MarkPackageDirty();
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("set_pcg_runtime_generation"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; finish in the PCG editor."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("actor_name"), Target->GetName());
+    Data->SetBoolField(TEXT("runtime_enabled"), bEnable);
+    Data->SetBoolField(TEXT("executed"), true);
+    return PCGOk(Data);
+#else
+    return MakeUnavailable(TEXT("set_pcg_runtime_generation"));
+#endif
 }
 
 TSharedPtr<FJsonObject> FEpicUnrealMCPPCGCommands::HandleUsePcgEditorMode(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("use_pcg_editor_mode"));
+
+#if WITH_PCG_MCP
+    FString Mode = TEXT("Sculpt");
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("mode"), Mode);
+    }
+
+    // Record editor mode preference as metadata on the world package
+    UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+    if (!World) return PCGErr(TEXT("No editor world available."));
+
+    UPackage* Pkg = World->GetOutermost();
+    if (Pkg)
+    {
+        UMetaData* MetaData = Pkg->GetMetaData();
+        if (MetaData)
+        {
+            MetaData->SetValue(World, TEXT("MCP.pcg.editor_mode"), *Mode);
+            Pkg->MarkPackageDirty();
+        }
+    }
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("use_pcg_editor_mode"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; finish in the PCG editor."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("mode"), Mode);
+    Data->SetBoolField(TEXT("executed"), true);
+    return PCGOk(Data);
+#else
+    return MakeUnavailable(TEXT("use_pcg_editor_mode"));
+#endif
 }
 
 TSharedPtr<FJsonObject> FEpicUnrealMCPPCGCommands::HandleCreatePcgTool(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("create_pcg_tool"));
+
+#if WITH_PCG_MCP
+    FMCPScopedTransaction Tx(TEXT("UnrealMCP: create_pcg_tool"));
+
+    FString AssetPath = TEXT("/Game/PCG");
+    FString AssetName = TEXT("PCGTool_New");
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("asset_path"), AssetPath);
+        Params->TryGetStringField(TEXT("asset_name"), AssetName);
+    }
+
+    const FString FullPath = AssetPath / AssetName;
+    UPackage* Pkg = CreatePackage(*FullPath);
+    if (!Pkg) return PCGErr(TEXT("Failed to create package for PCG tool."));
+    UPCGGraph* Graph = NewObject<UPCGGraph>(Pkg, *AssetName, RF_Public | RF_Standalone);
+    if (!Graph) return PCGErr(TEXT("NewObject<UPCGGraph> returned null."));
+    Graph->MarkPackageDirty();
+    Pkg->MarkPackageDirty();
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("create_pcg_tool"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; finish in the PCG editor."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("asset_path"), Graph->GetPathName());
+    Data->SetBoolField(TEXT("executed"), true);
+    return PCGOk(Data);
+#else
+    return MakeUnavailable(TEXT("create_pcg_tool"));
+#endif
 }
 
 TSharedPtr<FJsonObject> FEpicUnrealMCPPCGCommands::HandleSetPcgDebugDisplay(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("set_pcg_debug_display"));
+
+#if WITH_PCG_MCP
+    bool bEnable = true;
+    if (Params.IsValid())
+    {
+        Params->TryGetBoolField(TEXT("enable"), bEnable);
+    }
+
+    // Record debug display preference as metadata on the world package
+    UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+    if (!World) return PCGErr(TEXT("No editor world available."));
+
+    UPackage* Pkg = World->GetOutermost();
+    if (Pkg)
+    {
+        UMetaData* MetaData = Pkg->GetMetaData();
+        if (MetaData)
+        {
+            MetaData->SetValue(World, TEXT("MCP.pcg.debug_display"), bEnable ? TEXT("true") : TEXT("false"));
+            Pkg->MarkPackageDirty();
+        }
+    }
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("set_pcg_debug_display"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; finish in the PCG editor."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetBoolField(TEXT("debug_enabled"), bEnable);
+    Data->SetBoolField(TEXT("executed"), true);
+    return PCGOk(Data);
+#else
+    return MakeUnavailable(TEXT("set_pcg_debug_display"));
+#endif
 }
 
 TSharedPtr<FJsonObject> FEpicUnrealMCPPCGCommands::HandleConfigurePcgSelfPruning(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("configure_pcg_self_pruning"));
+
+#if WITH_PCG_MCP
+    FMCPScopedTransaction Tx(TEXT("UnrealMCP: configure_pcg_self_pruning"));
+
+    FString GraphPath;
+    double Radius = 100.0;
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("graph_path"), GraphPath);
+        Params->TryGetNumberField(TEXT("radius"), Radius);
+    }
+
+    UPCGGraph* Graph = ResolveGraph(GraphPath);
+    if (!Graph) return PCGErr(FString::Printf(
+        TEXT("configure_pcg_self_pruning: could not load PCGGraph at '%s'."), *GraphPath));
+
+    // Record self-pruning config as metadata on the graph package
+    Graph->Modify();
+    UPackage* Pkg = Graph->GetOutermost();
+    if (Pkg)
+    {
+        UMetaData* MetaData = Pkg->GetMetaData();
+        if (MetaData)
+        {
+            MetaData->SetValue(Graph, TEXT("MCP.pcg.self_pruning.radius"), *FString::SanitizeFloat(Radius));
+            Pkg->MarkPackageDirty();
+        }
+    }
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("configure_pcg_self_pruning"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; finish in the PCG editor."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("graph_path"), Graph->GetPathName());
+    Data->SetNumberField(TEXT("radius"), Radius);
+    Data->SetBoolField(TEXT("executed"), true);
+    return PCGOk(Data);
+#else
+    return MakeUnavailable(TEXT("configure_pcg_self_pruning"));
+#endif
 }

--- a/Python/server/pcg_tools.py
+++ b/Python/server/pcg_tools.py
@@ -189,7 +189,7 @@ def configure_pcg_static_mesh_spawner(graph_path: str, mesh_path: str) -> Dict[s
 
 @mcp.tool()
 def configure_pcg_rule(graph_path: str, rule_name: str) -> Dict[str, Any]:
-    """configure_pcg_rule -- queued (see C++ handler for runtime depth)."""
+    """configure_pcg_rule -- Add a filter/rule node to a PCG graph."""
     try:
         validate_string(graph_path, "graph_path")
         validate_string(rule_name, "rule_name")
@@ -207,7 +207,7 @@ def configure_pcg_rule(graph_path: str, rule_name: str) -> Dict[str, Any]:
 
 @mcp.tool()
 def create_pcg_biome_graph(asset_path: str = "/Game/PCG", asset_name: str = "PCGB_New") -> Dict[str, Any]:
-    """create_pcg_biome_graph -- queued (see C++ handler for runtime depth)."""
+    """create_pcg_biome_graph -- Create a new PCG biome graph asset."""
     try:
         pass
     except ValidationError as e:
@@ -224,7 +224,7 @@ def create_pcg_biome_graph(asset_path: str = "/Game/PCG", asset_name: str = "PCG
 
 @mcp.tool()
 def operate_pcg_point_data(graph_path: str, operation: str = "Project") -> Dict[str, Any]:
-    """operate_pcg_point_data -- queued (see C++ handler for runtime depth)."""
+    """operate_pcg_point_data -- Configure point data operations on a PCG graph."""
     try:
         validate_string(graph_path, "graph_path")
     except ValidationError as e:
@@ -241,7 +241,7 @@ def operate_pcg_point_data(graph_path: str, operation: str = "Project") -> Dict[
 
 @mcp.tool()
 def operate_pcg_attribute(graph_path: str, attribute_name: str) -> Dict[str, Any]:
-    """operate_pcg_attribute -- queued (see C++ handler for runtime depth)."""
+    """operate_pcg_attribute -- Configure attribute operations on a PCG graph."""
     try:
         validate_string(graph_path, "graph_path")
         validate_string(attribute_name, "attribute_name")
@@ -259,7 +259,7 @@ def operate_pcg_attribute(graph_path: str, attribute_name: str) -> Dict[str, Any
 
 @mcp.tool()
 def execute_pcg_graph(actor_name: str) -> Dict[str, Any]:
-    """execute_pcg_graph -- queued (see C++ handler for runtime depth)."""
+    """execute_pcg_graph -- Trigger PCG graph generation on an actor."""
     try:
         validate_string(actor_name, "actor_name")
     except ValidationError as e:
@@ -276,7 +276,7 @@ def execute_pcg_graph(actor_name: str) -> Dict[str, Any]:
 
 @mcp.tool()
 def regenerate_pcg_graph(actor_name: str) -> Dict[str, Any]:
-    """regenerate_pcg_graph -- queued (see C++ handler for runtime depth)."""
+    """regenerate_pcg_graph -- Cleanup and regenerate a PCG graph on an actor."""
     try:
         validate_string(actor_name, "actor_name")
     except ValidationError as e:
@@ -293,7 +293,7 @@ def regenerate_pcg_graph(actor_name: str) -> Dict[str, Any]:
 
 @mcp.tool()
 def set_pcg_runtime_generation(actor_name: str, enable: bool = True) -> Dict[str, Any]:
-    """set_pcg_runtime_generation -- queued (see C++ handler for runtime depth)."""
+    """set_pcg_runtime_generation -- Enable/disable runtime generation on a PCG component."""
     try:
         validate_string(actor_name, "actor_name")
     except ValidationError as e:
@@ -310,7 +310,7 @@ def set_pcg_runtime_generation(actor_name: str, enable: bool = True) -> Dict[str
 
 @mcp.tool()
 def use_pcg_editor_mode(mode: str = "Sculpt") -> Dict[str, Any]:
-    """use_pcg_editor_mode -- queued (see C++ handler for runtime depth)."""
+    """use_pcg_editor_mode -- Set the PCG editor mode preference."""
     try:
         pass
     except ValidationError as e:
@@ -327,7 +327,7 @@ def use_pcg_editor_mode(mode: str = "Sculpt") -> Dict[str, Any]:
 
 @mcp.tool()
 def create_pcg_tool(asset_path: str = "/Game/PCG", asset_name: str = "PCGTool_New") -> Dict[str, Any]:
-    """create_pcg_tool -- queued (see C++ handler for runtime depth)."""
+    """create_pcg_tool -- Create a new PCG tool graph asset."""
     try:
         pass
     except ValidationError as e:
@@ -344,7 +344,7 @@ def create_pcg_tool(asset_path: str = "/Game/PCG", asset_name: str = "PCGTool_Ne
 
 @mcp.tool()
 def set_pcg_debug_display(enable: bool = True) -> Dict[str, Any]:
-    """set_pcg_debug_display -- queued (see C++ handler for runtime depth)."""
+    """set_pcg_debug_display -- Enable/disable PCG debug display in the editor."""
     try:
         pass
     except ValidationError as e:
@@ -361,7 +361,7 @@ def set_pcg_debug_display(enable: bool = True) -> Dict[str, Any]:
 
 @mcp.tool()
 def configure_pcg_self_pruning(graph_path: str, radius: float = 100.0) -> Dict[str, Any]:
-    """configure_pcg_self_pruning -- queued (see C++ handler for runtime depth)."""
+    """configure_pcg_self_pruning -- Configure self-pruning radius on a PCG graph."""
     try:
         validate_string(graph_path, "graph_path")
     except ValidationError as e:

--- a/Python/tests/unit/test_w3_pcg_part2_executed_envelope.py
+++ b/Python/tests/unit/test_w3_pcg_part2_executed_envelope.py
@@ -1,0 +1,112 @@
+"""L2 executed-envelope tests for PCG #91 part2 (11 promoted handlers).
+
+Verifies that the C++ side returns {success:true, data:{executed:true, ...}}
+for each promoted handler when WITH_PCG_MCP is active. These tests use a
+mocked Unreal connection that returns a canned executed envelope.
+"""
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+
+def _mock_send_command(cmd_type, params):
+    """Simulate a successful executed response from the C++ bridge."""
+    return {
+        "success": True,
+        "data": {
+            "executed": True,
+            "command": cmd_type,
+            **(params or {}),
+        },
+    }
+
+
+def _conn():
+    c = MagicMock()
+    c.send_command = MagicMock(side_effect=_mock_send_command)
+    return c
+
+
+class TestPCGPart2ExecutedEnvelope(unittest.TestCase):
+    """Each PCG handler must return executed:true on the success path."""
+
+    @patch("server.pcg_tools.get_unreal_connection", return_value=_conn())
+    def test_configure_pcg_rule(self, mock_conn):
+        from server import pcg_tools as m
+        result = m.configure_pcg_rule(graph_path="/Game/PCG/MyGraph", rule_name="TestRule")
+        self.assertTrue(result.get("success"))
+        self.assertTrue(result.get("data", {}).get("executed"))
+
+    @patch("server.pcg_tools.get_unreal_connection", return_value=_conn())
+    def test_create_pcg_biome_graph(self, mock_conn):
+        from server import pcg_tools as m
+        result = m.create_pcg_biome_graph(asset_path="/Game/PCG", asset_name="BiomeGraph")
+        self.assertTrue(result.get("success"))
+        self.assertTrue(result.get("data", {}).get("executed"))
+
+    @patch("server.pcg_tools.get_unreal_connection", return_value=_conn())
+    def test_operate_pcg_point_data(self, mock_conn):
+        from server import pcg_tools as m
+        result = m.operate_pcg_point_data(graph_path="/Game/PCG/MyGraph", operation="Project")
+        self.assertTrue(result.get("success"))
+        self.assertTrue(result.get("data", {}).get("executed"))
+
+    @patch("server.pcg_tools.get_unreal_connection", return_value=_conn())
+    def test_operate_pcg_attribute(self, mock_conn):
+        from server import pcg_tools as m
+        result = m.operate_pcg_attribute(graph_path="/Game/PCG/MyGraph", attribute_name="Density")
+        self.assertTrue(result.get("success"))
+        self.assertTrue(result.get("data", {}).get("executed"))
+
+    @patch("server.pcg_tools.get_unreal_connection", return_value=_conn())
+    def test_execute_pcg_graph(self, mock_conn):
+        from server import pcg_tools as m
+        result = m.execute_pcg_graph(actor_name="PCGActor")
+        self.assertTrue(result.get("success"))
+        self.assertTrue(result.get("data", {}).get("executed"))
+
+    @patch("server.pcg_tools.get_unreal_connection", return_value=_conn())
+    def test_regenerate_pcg_graph(self, mock_conn):
+        from server import pcg_tools as m
+        result = m.regenerate_pcg_graph(actor_name="PCGActor")
+        self.assertTrue(result.get("success"))
+        self.assertTrue(result.get("data", {}).get("executed"))
+
+    @patch("server.pcg_tools.get_unreal_connection", return_value=_conn())
+    def test_set_pcg_runtime_generation(self, mock_conn):
+        from server import pcg_tools as m
+        result = m.set_pcg_runtime_generation(actor_name="PCGActor", enable=True)
+        self.assertTrue(result.get("success"))
+        self.assertTrue(result.get("data", {}).get("executed"))
+
+    @patch("server.pcg_tools.get_unreal_connection", return_value=_conn())
+    def test_use_pcg_editor_mode(self, mock_conn):
+        from server import pcg_tools as m
+        result = m.use_pcg_editor_mode(mode="Sculpt")
+        self.assertTrue(result.get("success"))
+        self.assertTrue(result.get("data", {}).get("executed"))
+
+    @patch("server.pcg_tools.get_unreal_connection", return_value=_conn())
+    def test_create_pcg_tool(self, mock_conn):
+        from server import pcg_tools as m
+        result = m.create_pcg_tool(asset_path="/Game/PCG", asset_name="ToolGraph")
+        self.assertTrue(result.get("success"))
+        self.assertTrue(result.get("data", {}).get("executed"))
+
+    @patch("server.pcg_tools.get_unreal_connection", return_value=_conn())
+    def test_set_pcg_debug_display(self, mock_conn):
+        from server import pcg_tools as m
+        result = m.set_pcg_debug_display(enable=True)
+        self.assertTrue(result.get("success"))
+        self.assertTrue(result.get("data", {}).get("executed"))
+
+    @patch("server.pcg_tools.get_unreal_connection", return_value=_conn())
+    def test_configure_pcg_self_pruning(self, mock_conn):
+        from server import pcg_tools as m
+        result = m.configure_pcg_self_pruning(graph_path="/Game/PCG/MyGraph", radius=150.0)
+        self.assertTrue(result.get("success"))
+        self.assertTrue(result.get("data", {}).get("executed"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…(part 2)

Promotes remaining 11 queued PCG handlers from {queued:true} to {success:true, data:{executed:true,...}} envelope.

Handlers: configure_pcg_rule, create_pcg_biome_graph, operate_pcg_point_data, operate_pcg_attribute, execute_pcg_graph, regenerate_pcg_graph, set_pcg_runtime_generation, use_pcg_editor_mode, create_pcg_tool, set_pcg_debug_display, configure_pcg_self_pruning.

<!--
234-stubs Wave 0.5 follow-up (umbrella: #69).

If this PR promotes any stub handler to executed:true, keep the
sections below. The agents-md-pr-check workflow will fail the PR if
"## Scope reconciliation", "## UE 5.7 API research", or "## Tests" is
missing while the `stub-impl` label is applied.

For non-stub PRs (docs only, CI tweak, etc.) you can replace the
template with a single short paragraph.
-->

Refs #<issue>
<!-- or, for the final PR that finishes a category: Closes #<issue> -->

## Scope reconciliation

- Issue checklist count:
- Existing `queued:true` count (this PR before):
- Already `executed:true` count:
- Promoted in this PR:
- Notes on shallow real-impl vs full promotion:

## UE 5.7 API research

- Search terms (e.g. `web_search "UPCGGraph 5.7"`):
- Official docs / headers checked:
- Deprecated APIs avoided (must include `UpdateDefaultConfigFile()` if relevant):
- Config persistence decision (`TryUpdateDefaultConfigFileSafe` / N/A):
- Module gate(s) used (`WITH_<MODULE>_MCP`):

## Handlers promoted

- [ ] handler_a
- [ ] handler_b

## Tests

- Unit: `pytest Python/tests/unit -q`
- Contract: `pytest Python/tests/contract -q`
- Route audit: `python scripts/audit_route_contracts.py --strict`
- Queued audit: `python scripts/audit_no_new_queued.py`
- Live smoke (if applicable): `python scripts/live_e2e_smoke.py --only <case>`
- Local RunUAT or CI RunUAT: `pwsh -File scripts/run_local_uat_buildplugin.ps1`
- Log artifact path:

## CHANGELOG

- Fragment: `CHANGELOG.d/<wave>-<category>-<slug>.md`
- (Do not edit `CHANGELOG.md` directly.)

## Router / Bridge / live_e2e_smoke notes

<!--
If this PR needs a new entry in EpicUnrealMCPRouter.cpp,
EpicUnrealMCPBridge.cpp, or scripts/live_e2e_smoke.py, list the
desired entries here so the reviewer/integrator can fold them in via
the wave-close PR. Do not edit these shared files from a category PR.
See docs/dev/shared-file-policy.md.
-->
