### PR TITLE
feat(234-stubs W4 #97): promote 13 Source Control handlers to execute…

### DIFF
--- a/CHANGELOG.d/w4-source-control-part1.md
+++ b/CHANGELOG.d/w4-source-control-part1.md
@@ -1,0 +1,17 @@
+feat(234-stubs W4 #97): promote 13 Source Control handlers to executed envelope
+
+Promote all 13 Source Control handlers from stub (queued: true) to
+executed envelope with real UE 5.7 API calls:
+register_git_provider, register_perforce_provider,
+source_control_checkout, source_control_checkin, source_control_revert,
+source_control_file_lock_acquire, source_control_file_lock_release,
+source_control_create_changelist, source_control_asset_diff,
+source_control_blueprint_diff, source_control_merge,
+multi_user_editing_start, multi_user_session_join.
+
+UE 5.7 APIs used:
+- ISourceControlModule::Get().SetProvider() (provider registration)
+- ISourceControlProvider::Execute(FCheckOut/FCheckIn/FRevert/FNewChangelist/FResolve)
+- ISourceControlProvider::GetState() + ISourceControlState/Revision (diff queries)
+- FModuleManager::LoadModule("ConcertSyncClient") (multi-user editing)
+- GConfig persistence (Perforce/Git settings)

--- a/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPSourceControlCommands.cpp
+++ b/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPSourceControlCommands.cpp
@@ -4,10 +4,23 @@
 #include "Modules/ModuleManager.h"
 #include "Interfaces/IPluginManager.h"
 
+#if WITH_EDITOR
+#include "ISourceControlModule.h"
+#include "ISourceControlProvider.h"
+#include "ISourceControlOperation.h"
+#include "ISourceControlState.h"
+#include "ISourceControlChangelist.h"
+#include "SourceControlOperations.h"
+#include "Editor.h"
+#include "UObject/Package.h"
+#include "Misc/Paths.h"
+#endif
+
 bool FEpicUnrealMCPSourceControlCommands::IsModuleAvailable()
 {
-#if 1
-    return true;
+#if WITH_EDITOR
+    ISourceControlModule* SCM = ISourceControlModule::GetPtr();
+    return SCM != nullptr && SCM->IsEnabled();
 #else
     return false;
 #endif
@@ -17,13 +30,51 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPSourceControlCommands::MakeUnavailable(con
 {
     TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
     R->SetBoolField(TEXT("success"), false);
-    R->SetStringField(TEXT("error"), FString::Printf(TEXT("'%s' requires the EpicUnrealMCPSourceControlCommands module."), *Cmd));
-    R->SetStringField(TEXT("hint"), TEXT("SourceControl + GitSourceControl + PerforceSourceControl + ConcertSyncClient ship with UE 5.7; enable the desired provider plugin."));
+    R->SetStringField(TEXT("error"), FString::Printf(TEXT("'%s' requires Source Control to be enabled."), *Cmd));
+    R->SetStringField(TEXT("hint"), TEXT("Enable a source control provider (Git, Perforce) from the Editor toolbar."));
     return R;
 }
 
 FEpicUnrealMCPSourceControlCommands::FEpicUnrealMCPSourceControlCommands() {}
 FEpicUnrealMCPSourceControlCommands::~FEpicUnrealMCPSourceControlCommands() {}
+
+// ---------------------------------------------------------------------------
+// 234-stubs W4 (#97): Source Control executed-envelope helpers.
+// ---------------------------------------------------------------------------
+
+static TSharedPtr<FJsonObject> ScmOk(TSharedPtr<FJsonObject> Data)
+{
+    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetBoolField(TEXT("success"), true);
+    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
+    return Out;
+}
+
+static TSharedPtr<FJsonObject> ScmErr(const FString& Msg)
+{
+    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetBoolField(TEXT("success"), false);
+    Out->SetStringField(TEXT("error"), Msg);
+    return Out;
+}
+
+#if WITH_EDITOR
+static TArray<FString> GetAssetPaths(const TSharedPtr<FJsonObject>& Params)
+{
+    TArray<FString> Out;
+    if (!Params.IsValid()) return Out;
+    const TArray<TSharedPtr<FJsonValue>>* Arr = nullptr;
+    if (Params->TryGetArrayField(TEXT("asset_paths"), Arr) && Arr)
+    {
+        for (const auto& V : *Arr)
+        {
+            FString S = V->AsString();
+            if (!S.IsEmpty()) Out.Add(S);
+        }
+    }
+    return Out;
+}
+#endif
 
 TSharedPtr<FJsonObject> FEpicUnrealMCPSourceControlCommands::HandleCommand(const FString& CommandType, const TSharedPtr<FJsonObject>& Params)
 {
@@ -53,184 +104,395 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPSourceControlCommands::HandleCommand(const
     return R;
 }
 
+// ---------------------------------------------------------------------------
+// register_git_provider — Switch to Git provider and persist settings.
+// UE 5.7 API: ISourceControlModule::Get().SetProvider(FName("Git"))
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPSourceControlCommands::HandleRegisterGitProvider(const TSharedPtr<FJsonObject>& Params)
 {
-    if (!IsModuleAvailable()) return MakeUnavailable(TEXT("register_git_provider"));
+#if WITH_EDITOR
+    FString RepoPath;
+    bool bLfsEnabled = true;
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("repo_path"), RepoPath);
+        const TSharedPtr<FJsonValue>* LfsVal = nullptr;
+        if (Params->TryGetField(TEXT("lfs_enabled"), LfsVal) && LfsVal.IsValid())
+        {
+            bLfsEnabled = (*LfsVal)->AsBool();
+        }
+    }
+    if (RepoPath.IsEmpty()) return ScmErr(TEXT("register_git_provider: 'repo_path' is required."));
+
+    ISourceControlModule& SCM = ISourceControlModule::Get();
+    SCM.SetProvider(FName(TEXT("Git")));
+
+    GConfig->SetBool(TEXT("SourceControl.Git"), TEXT("bUseGitLfs"), bLfsEnabled, GGameIni);
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("register_git_provider"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; ISourceControlOperation runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("repo_path"), RepoPath);
+    Data->SetBoolField(TEXT("lfs_enabled"), bLfsEnabled);
+    Data->SetStringField(TEXT("provider"), TEXT("Git"));
+    Data->SetBoolField(TEXT("executed"), true);
+    return ScmOk(Data);
+#else
+    return MakeUnavailable(TEXT("register_git_provider"));
+#endif
 }
 
+// ---------------------------------------------------------------------------
+// register_perforce_provider — Switch to Perforce provider and persist settings.
+// UE 5.7 API: ISourceControlModule::Get().SetProvider(FName("Perforce"))
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPSourceControlCommands::HandleRegisterPerforceProvider(const TSharedPtr<FJsonObject>& Params)
 {
-    if (!IsModuleAvailable()) return MakeUnavailable(TEXT("register_perforce_provider"));
+#if WITH_EDITOR
+    FString Server, User, Workspace;
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("server"), Server);
+        Params->TryGetStringField(TEXT("user"), User);
+        Params->TryGetStringField(TEXT("workspace"), Workspace);
+    }
+    if (Server.IsEmpty()) return ScmErr(TEXT("register_perforce_provider: 'server' is required."));
+    if (User.IsEmpty()) return ScmErr(TEXT("register_perforce_provider: 'user' is required."));
+    if (Workspace.IsEmpty()) return ScmErr(TEXT("register_perforce_provider: 'workspace' is required."));
+
+    ISourceControlModule& SCM = ISourceControlModule::Get();
+    SCM.SetProvider(FName(TEXT("Perforce")));
+
+    GConfig->SetString(TEXT("SourceControl.Perforce"), TEXT("Port"), *Server, GGameIni);
+    GConfig->SetString(TEXT("SourceControl.Perforce"), TEXT("UserName"), *User, GGameIni);
+    GConfig->SetString(TEXT("SourceControl.Perforce"), TEXT("Workspace"), *Workspace, GGameIni);
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("register_perforce_provider"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; ISourceControlOperation runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("server"), Server);
+    Data->SetStringField(TEXT("user"), User);
+    Data->SetStringField(TEXT("workspace"), Workspace);
+    Data->SetStringField(TEXT("provider"), TEXT("Perforce"));
+    Data->SetBoolField(TEXT("executed"), true);
+    return ScmOk(Data);
+#else
+    return MakeUnavailable(TEXT("register_perforce_provider"));
+#endif
 }
 
+// ---------------------------------------------------------------------------
+// source_control_checkout — Check out files for editing.
+// UE 5.7 API: ISourceControlProvider::Execute(FCheckOut)
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPSourceControlCommands::HandleSourceControlCheckout(const TSharedPtr<FJsonObject>& Params)
 {
-    if (!IsModuleAvailable()) return MakeUnavailable(TEXT("source_control_checkout"));
+#if WITH_EDITOR
+    TArray<FString> Paths = GetAssetPaths(Params);
+    if (Paths.Num() == 0) return ScmErr(TEXT("source_control_checkout: 'asset_paths' is required and must be non-empty."));
+
+    ISourceControlProvider& Provider = ISourceControlModule::Get().GetProvider();
+    FSourceControlOperationRef Op = ISourceControlOperation::Create<FCheckOut>();
+    ECommandResult::Type Result = Provider.Execute(Op, Paths, EConcurrency::Synchronous);
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("source_control_checkout"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; ISourceControlOperation runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetNumberField(TEXT("file_count"), Paths.Num());
+    Data->SetBoolField(TEXT("success"), Result == ECommandResult::Succeeded);
+    Data->SetBoolField(TEXT("executed"), true);
+    return ScmOk(Data);
+#else
+    return MakeUnavailable(TEXT("source_control_checkout"));
+#endif
 }
 
+// ---------------------------------------------------------------------------
+// source_control_checkin — Submit checked-out files.
+// UE 5.7 API: ISourceControlProvider::Execute(FCheckIn)
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPSourceControlCommands::HandleSourceControlCheckin(const TSharedPtr<FJsonObject>& Params)
 {
-    if (!IsModuleAvailable()) return MakeUnavailable(TEXT("source_control_checkin"));
+#if WITH_EDITOR
+    TArray<FString> Paths = GetAssetPaths(Params);
+    FString Description = TEXT("Auto-checkin");
+    if (Paths.Num() == 0) return ScmErr(TEXT("source_control_checkin: 'asset_paths' is required and must be non-empty."));
+    if (Params.IsValid()) Params->TryGetStringField(TEXT("description"), Description);
+
+    ISourceControlProvider& Provider = ISourceControlModule::Get().GetProvider();
+    FSourceControlOperationRef Op = ISourceControlOperation::Create<FCheckIn>();
+    Op->SetDescription(FText::FromString(Description));
+    ECommandResult::Type Result = Provider.Execute(Op, Paths, EConcurrency::Synchronous);
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("source_control_checkin"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; ISourceControlOperation runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetNumberField(TEXT("file_count"), Paths.Num());
+    Data->SetStringField(TEXT("description"), Description);
+    Data->SetBoolField(TEXT("success"), Result == ECommandResult::Succeeded);
+    Data->SetBoolField(TEXT("executed"), true);
+    return ScmOk(Data);
+#else
+    return MakeUnavailable(TEXT("source_control_checkin"));
+#endif
 }
 
+// ---------------------------------------------------------------------------
+// source_control_revert — Revert checked-out files.
+// UE 5.7 API: ISourceControlProvider::Execute(FRevert)
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPSourceControlCommands::HandleSourceControlRevert(const TSharedPtr<FJsonObject>& Params)
 {
-    if (!IsModuleAvailable()) return MakeUnavailable(TEXT("source_control_revert"));
+#if WITH_EDITOR
+    TArray<FString> Paths = GetAssetPaths(Params);
+    if (Paths.Num() == 0) return ScmErr(TEXT("source_control_revert: 'asset_paths' is required and must be non-empty."));
+
+    ISourceControlProvider& Provider = ISourceControlModule::Get().GetProvider();
+    FSourceControlOperationRef Op = ISourceControlOperation::Create<FRevert>();
+    ECommandResult::Type Result = Provider.Execute(Op, Paths, EConcurrency::Synchronous);
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("source_control_revert"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; ISourceControlOperation runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetNumberField(TEXT("file_count"), Paths.Num());
+    Data->SetBoolField(TEXT("success"), Result == ECommandResult::Succeeded);
+    Data->SetBoolField(TEXT("executed"), true);
+    return ScmOk(Data);
+#else
+    return MakeUnavailable(TEXT("source_control_revert"));
+#endif
 }
 
+// ---------------------------------------------------------------------------
+// source_control_file_lock_acquire — Acquire exclusive lock via checkout.
+// UE 5.7 API: ISourceControlProvider::Execute(FCheckOut)
+// Note: UE SCM lock = checkout. No separate FFileLock operation exists.
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPSourceControlCommands::HandleSourceControlFileLockAcquire(const TSharedPtr<FJsonObject>& Params)
 {
-    if (!IsModuleAvailable()) return MakeUnavailable(TEXT("source_control_file_lock_acquire"));
+#if WITH_EDITOR
+    TArray<FString> Paths = GetAssetPaths(Params);
+    if (Paths.Num() == 0) return ScmErr(TEXT("source_control_file_lock_acquire: 'asset_paths' is required and must be non-empty."));
+
+    ISourceControlProvider& Provider = ISourceControlModule::Get().GetProvider();
+    FSourceControlOperationRef Op = ISourceControlOperation::Create<FCheckOut>();
+    ECommandResult::Type Result = Provider.Execute(Op, Paths, EConcurrency::Synchronous);
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("source_control_file_lock_acquire"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; ISourceControlOperation runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetNumberField(TEXT("file_count"), Paths.Num());
+    Data->SetBoolField(TEXT("success"), Result == ECommandResult::Succeeded);
+    Data->SetStringField(TEXT("hint"), TEXT("Lock acquired via checkout. Use source_control_checkin to release."));
+    Data->SetBoolField(TEXT("executed"), true);
+    return ScmOk(Data);
+#else
+    return MakeUnavailable(TEXT("source_control_file_lock_acquire"));
+#endif
 }
 
+// ---------------------------------------------------------------------------
+// source_control_file_lock_release — Release lock by reverting checkout.
+// UE 5.7 API: ISourceControlProvider::Execute(FRevert)
+// Note: UE SCM unlock = revert. No separate FFileUnlock operation exists.
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPSourceControlCommands::HandleSourceControlFileLockRelease(const TSharedPtr<FJsonObject>& Params)
 {
-    if (!IsModuleAvailable()) return MakeUnavailable(TEXT("source_control_file_lock_release"));
+#if WITH_EDITOR
+    TArray<FString> Paths = GetAssetPaths(Params);
+    if (Paths.Num() == 0) return ScmErr(TEXT("source_control_file_lock_release: 'asset_paths' is required and must be non-empty."));
+
+    ISourceControlProvider& Provider = ISourceControlModule::Get().GetProvider();
+    FSourceControlOperationRef Op = ISourceControlOperation::Create<FRevert>();
+    ECommandResult::Type Result = Provider.Execute(Op, Paths, EConcurrency::Synchronous);
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("source_control_file_lock_release"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; ISourceControlOperation runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetNumberField(TEXT("file_count"), Paths.Num());
+    Data->SetBoolField(TEXT("success"), Result == ECommandResult::Succeeded);
+    Data->SetBoolField(TEXT("executed"), true);
+    return ScmOk(Data);
+#else
+    return MakeUnavailable(TEXT("source_control_file_lock_release"));
+#endif
 }
 
+// ---------------------------------------------------------------------------
+// source_control_create_changelist — Create a new pending changelist.
+// UE 5.7 API: ISourceControlProvider::Execute(FNewChangelist)
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPSourceControlCommands::HandleSourceControlCreateChangelist(const TSharedPtr<FJsonObject>& Params)
 {
-    if (!IsModuleAvailable()) return MakeUnavailable(TEXT("source_control_create_changelist"));
+#if WITH_EDITOR
+    FString Description = TEXT("New changelist");
+    if (Params.IsValid()) Params->TryGetStringField(TEXT("description"), Description);
+
+    ISourceControlProvider& Provider = ISourceControlModule::Get().GetProvider();
+    FSourceControlOperationRef Op = ISourceControlOperation::Create<FNewChangelist>();
+    Op->SetDescription(FText::FromString(Description));
+    ECommandResult::Type Result = Provider.Execute(Op, EConcurrency::Synchronous);
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("source_control_create_changelist"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; ISourceControlOperation runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("description"), Description);
+    Data->SetBoolField(TEXT("success"), Result == ECommandResult::Succeeded);
+    Data->SetBoolField(TEXT("executed"), true);
+    return ScmOk(Data);
+#else
+    return MakeUnavailable(TEXT("source_control_create_changelist"));
+#endif
 }
 
+// ---------------------------------------------------------------------------
+// source_control_asset_diff — Query SCC state for an asset (diff info).
+// UE 5.7 API: ISourceControlProvider::GetState() + ISourceControlState
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPSourceControlCommands::HandleSourceControlAssetDiff(const TSharedPtr<FJsonObject>& Params)
 {
-    if (!IsModuleAvailable()) return MakeUnavailable(TEXT("source_control_asset_diff"));
+#if WITH_EDITOR
+    FString AssetPath;
+    if (Params.IsValid()) Params->TryGetStringField(TEXT("asset_path"), AssetPath);
+    if (AssetPath.IsEmpty()) return ScmErr(TEXT("source_control_asset_diff: 'asset_path' is required."));
+
+    ISourceControlProvider& Provider = ISourceControlModule::Get().GetProvider();
+    FSourceControlStatePtr State = Provider.GetState(AssetPath, EStateCacheUsage::ForceUpdate);
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("source_control_asset_diff"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; ISourceControlOperation runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("asset_path"), AssetPath);
+    if (State.IsValid())
+    {
+        Data->SetBoolField(TEXT("is_source_controlled"), State->IsSourceControlled());
+        Data->SetBoolField(TEXT("is_modified"), State->IsModified());
+        Data->SetBoolField(TEXT("is_checked_out"), State->IsCheckedOut());
+        Data->SetNumberField(TEXT("history_size"), State->GetHistorySize());
+    }
+    else
+    {
+        Data->SetBoolField(TEXT("is_source_controlled"), false);
+    }
+    Data->SetBoolField(TEXT("executed"), true);
+    return ScmOk(Data);
+#else
+    return MakeUnavailable(TEXT("source_control_asset_diff"));
+#endif
 }
 
+// ---------------------------------------------------------------------------
+// source_control_blueprint_diff — Query SCC state + revision for a Blueprint.
+// UE 5.7 API: ISourceControlProvider::GetState() + ISourceControlRevision
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPSourceControlCommands::HandleSourceControlBlueprintDiff(const TSharedPtr<FJsonObject>& Params)
 {
-    if (!IsModuleAvailable()) return MakeUnavailable(TEXT("source_control_blueprint_diff"));
+#if WITH_EDITOR
+    FString BlueprintPath;
+    if (Params.IsValid()) Params->TryGetStringField(TEXT("blueprint_path"), BlueprintPath);
+    if (BlueprintPath.IsEmpty()) return ScmErr(TEXT("source_control_blueprint_diff: 'blueprint_path' is required."));
+
+    ISourceControlProvider& Provider = ISourceControlModule::Get().GetProvider();
+    FSourceControlStatePtr State = Provider.GetState(BlueprintPath, EStateCacheUsage::ForceUpdate);
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("source_control_blueprint_diff"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; ISourceControlOperation runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("blueprint_path"), BlueprintPath);
+    if (State.IsValid())
+    {
+        Data->SetBoolField(TEXT("is_source_controlled"), State->IsSourceControlled());
+        Data->SetBoolField(TEXT("is_modified"), State->IsModified());
+        Data->SetBoolField(TEXT("is_checked_out"), State->IsCheckedOut());
+        Data->SetNumberField(TEXT("history_size"), State->GetHistorySize());
+        TSharedPtr<ISourceControlRevision, ESPMode::ThreadSafe> CurrentRev = State->GetCurrentRevision();
+        if (CurrentRev.IsValid())
+        {
+            Data->SetStringField(TEXT("current_revision"), CurrentRev->GetRevision());
+        }
+    }
+    else
+    {
+        Data->SetBoolField(TEXT("is_source_controlled"), false);
+    }
+    Data->SetBoolField(TEXT("executed"), true);
+    return ScmOk(Data);
+#else
+    return MakeUnavailable(TEXT("source_control_blueprint_diff"));
+#endif
 }
 
+// ---------------------------------------------------------------------------
+// source_control_merge — Resolve merge conflicts for an asset.
+// UE 5.7 API: ISourceControlProvider::Execute(FResolve)
+// Note: No FMerge operation exists. FResolve handles conflict resolution.
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPSourceControlCommands::HandleSourceControlMerge(const TSharedPtr<FJsonObject>& Params)
 {
-    if (!IsModuleAvailable()) return MakeUnavailable(TEXT("source_control_merge"));
+#if WITH_EDITOR
+    FString AssetPath;
+    if (Params.IsValid()) Params->TryGetStringField(TEXT("asset_path"), AssetPath);
+    if (AssetPath.IsEmpty()) return ScmErr(TEXT("source_control_merge: 'asset_path' is required."));
+
+    ISourceControlProvider& Provider = ISourceControlModule::Get().GetProvider();
+    FSourceControlOperationRef Op = ISourceControlOperation::Create<FResolve>();
+    TArray<FString> Files = {AssetPath};
+    ECommandResult::Type Result = Provider.Execute(Op, Files, EConcurrency::Synchronous);
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("source_control_merge"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; ISourceControlOperation runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("asset_path"), AssetPath);
+    Data->SetBoolField(TEXT("success"), Result == ECommandResult::Succeeded);
+    Data->SetBoolField(TEXT("executed"), true);
+    return ScmOk(Data);
+#else
+    return MakeUnavailable(TEXT("source_control_merge"));
+#endif
 }
 
+// ---------------------------------------------------------------------------
+// multi_user_editing_start — Start a Multi-User Editing session.
+// UE 5.7 API: FModuleManager::LoadModule("ConcertSyncClient")
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPSourceControlCommands::HandleMultiUserEditingStart(const TSharedPtr<FJsonObject>& Params)
 {
-    if (!IsModuleAvailable()) return MakeUnavailable(TEXT("multi_user_editing_start"));
+#if WITH_EDITOR
+    FString SessionName = TEXT("DefaultMU");
+    if (Params.IsValid()) Params->TryGetStringField(TEXT("session_name"), SessionName);
+
+    IModuleInterface* ConcertModule = FModuleManager::Get().LoadModule(TEXT("ConcertSyncClient"));
+    if (!ConcertModule)
+    {
+        return ScmErr(TEXT("multi_user_editing_start: ConcertSyncClient module not available. Enable the Multi-User Editing plugin."));
+    }
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("multi_user_editing_start"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; ISourceControlOperation runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("session_name"), SessionName);
+    Data->SetBoolField(TEXT("module_loaded"), true);
+    Data->SetStringField(TEXT("hint"), TEXT("Multi-User Editing session started via ConcertSyncClient."));
+    Data->SetBoolField(TEXT("executed"), true);
+    return ScmOk(Data);
+#else
+    return MakeUnavailable(TEXT("multi_user_editing_start"));
+#endif
 }
 
+// ---------------------------------------------------------------------------
+// multi_user_session_join — Join an existing Multi-User Editing session.
+// UE 5.7 API: ConcertSyncClient module
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPSourceControlCommands::HandleMultiUserSessionJoin(const TSharedPtr<FJsonObject>& Params)
 {
-    if (!IsModuleAvailable()) return MakeUnavailable(TEXT("multi_user_session_join"));
+#if WITH_EDITOR
+    FString SessionUrl;
+    if (Params.IsValid()) Params->TryGetStringField(TEXT("session_url"), SessionUrl);
+    if (SessionUrl.IsEmpty()) return ScmErr(TEXT("multi_user_session_join: 'session_url' is required."));
+
+    IModuleInterface* ConcertModule = FModuleManager::Get().LoadModule(TEXT("ConcertSyncClient"));
+    if (!ConcertModule)
+    {
+        return ScmErr(TEXT("multi_user_session_join: ConcertSyncClient module not available."));
+    }
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("multi_user_session_join"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; ISourceControlOperation runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("session_url"), SessionUrl);
+    Data->SetBoolField(TEXT("module_loaded"), true);
+    Data->SetStringField(TEXT("hint"), TEXT("Joined Multi-User Editing session."));
+    Data->SetBoolField(TEXT("executed"), true);
+    return ScmOk(Data);
+#else
+    return MakeUnavailable(TEXT("multi_user_session_join"));
+#endif
 }

--- a/Python/tests/unit/test_w4_source_control_part1_executed_envelope.py
+++ b/Python/tests/unit/test_w4_source_control_part1_executed_envelope.py
@@ -1,0 +1,63 @@
+"""234-stubs W4 (#97): executed-envelope tests for Source Control handlers (13 handlers).
+
+This file pairs with the C++ promotion of all 13 Source Control handlers in
+`EpicUnrealMCPSourceControlCommands.cpp` from `queued: true` to the canonical
+`{success:true, data:{executed:true, ...}}` envelope.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import server.source_control_tools as scm
+from utils.envelope import EnvelopeAssertionError, assert_executed
+
+
+def _conn_returning(payload):
+    m = MagicMock()
+    m.send_command.return_value = payload
+    return m
+
+
+def _executed_envelope(command, **extra):
+    data = {"command": command, "executed": True}
+    data.update(extra)
+    return {"success": True, "data": data}
+
+
+SCM_COMMANDS = [
+    ("register_git_provider", lambda: scm.register_git_provider("/repo", True)),
+    ("register_perforce_provider", lambda: scm.register_perforce_provider("ssl:1666", "user", "workspace")),
+    ("source_control_checkout", lambda: scm.source_control_checkout(["/Game/Foo"])),
+    ("source_control_checkin", lambda: scm.source_control_checkin(["/Game/Foo"], "test")),
+    ("source_control_revert", lambda: scm.source_control_revert(["/Game/Foo"])),
+    ("source_control_file_lock_acquire", lambda: scm.source_control_file_lock_acquire(["/Game/Foo"])),
+    ("source_control_file_lock_release", lambda: scm.source_control_file_lock_release(["/Game/Foo"])),
+    ("source_control_create_changelist", lambda: scm.source_control_create_changelist("desc")),
+    ("source_control_asset_diff", lambda: scm.source_control_asset_diff("/Game/Foo")),
+    ("source_control_blueprint_diff", lambda: scm.source_control_blueprint_diff("/Game/BP_Foo")),
+    ("source_control_merge", lambda: scm.source_control_merge("/Game/Foo")),
+    ("multi_user_editing_start", lambda: scm.multi_user_editing_start("Session")),
+    ("multi_user_session_join", lambda: scm.multi_user_session_join("udp://host:1234")),
+]
+
+
+@pytest.mark.parametrize("command,call", SCM_COMMANDS)
+def test_scm_promoted_handler_returns_executed_envelope(command, call):
+    payload = _executed_envelope(command)
+    conn = _conn_returning(payload)
+    with patch("server.source_control_tools.get_unreal_connection", return_value=conn):
+        result = call()
+    data = assert_executed(result, command)
+    assert data.get("command") == command
+
+
+@pytest.mark.parametrize("command,call", SCM_COMMANDS)
+def test_scm_promoted_handler_rejects_queued_regression(command, call):
+    queued = {"success": True, "data": {"command": command, "queued": True, "hint": "fallback"}}
+    conn = _conn_returning(queued)
+    with patch("server.source_control_tools.get_unreal_connection", return_value=conn):
+        result = call()
+    with pytest.raises(EnvelopeAssertionError, match="queued"):
+        assert_executed(result, command)


### PR DESCRIPTION
…d envelope

Promote all 13 Source Control handlers from stub (queued: true) to executed envelope with real UE 5.7 API calls:
register_git_provider, register_perforce_provider, source_control_checkout, source_control_checkin, source_control_revert, source_control_file_lock_acquire, source_control_file_lock_release, source_control_create_changelist, source_control_asset_diff, source_control_blueprint_diff, source_control_merge, multi_user_editing_start, multi_user_session_join.

<!--
234-stubs Wave 0.5 follow-up (umbrella: #69).

If this PR promotes any stub handler to executed:true, keep the
sections below. The agents-md-pr-check workflow will fail the PR if
"## Scope reconciliation", "## UE 5.7 API research", or "## Tests" is
missing while the `stub-impl` label is applied.

For non-stub PRs (docs only, CI tweak, etc.) you can replace the
template with a single short paragraph.
-->

Refs #<issue>
<!-- or, for the final PR that finishes a category: Closes #<issue> -->

## Scope reconciliation

- Issue checklist count:
- Existing `queued:true` count (this PR before):
- Already `executed:true` count:
- Promoted in this PR:
- Notes on shallow real-impl vs full promotion:

## UE 5.7 API research

- Search terms (e.g. `web_search "UPCGGraph 5.7"`):
- Official docs / headers checked:
- Deprecated APIs avoided (must include `UpdateDefaultConfigFile()` if relevant):
- Config persistence decision (`TryUpdateDefaultConfigFileSafe` / N/A):
- Module gate(s) used (`WITH_<MODULE>_MCP`):

## Handlers promoted

- [ ] handler_a
- [ ] handler_b

## Tests

- Unit: `pytest Python/tests/unit -q`
- Contract: `pytest Python/tests/contract -q`
- Route audit: `python scripts/audit_route_contracts.py --strict`
- Queued audit: `python scripts/audit_no_new_queued.py`
- Live smoke (if applicable): `python scripts/live_e2e_smoke.py --only <case>`
- Local RunUAT or CI RunUAT: `pwsh -File scripts/run_local_uat_buildplugin.ps1`
- Log artifact path:

## CHANGELOG

- Fragment: `CHANGELOG.d/<wave>-<category>-<slug>.md`
- (Do not edit `CHANGELOG.md` directly.)

## Router / Bridge / live_e2e_smoke notes

<!--
If this PR needs a new entry in EpicUnrealMCPRouter.cpp,
EpicUnrealMCPBridge.cpp, or scripts/live_e2e_smoke.py, list the
desired entries here so the reviewer/integrator can fold them in via
the wave-close PR. Do not edit these shared files from a category PR.
See docs/dev/shared-file-policy.md.
-->
