### PR TITLE
Codex stubs w4 localization part1

### DIFF
--- a/CHANGELOG.d/w4-localization-part1.md
+++ b/CHANGELOG.d/w4-localization-part1.md
@@ -1,0 +1,12 @@
+### Changed
+- Promote 10 Localization handlers to executed envelope (#94)
+  - `open_localization_dashboard` — Show the Localization Dashboard editor tab
+  - `add_localization_culture` — Add a culture to a localization target
+  - `run_text_gather` — Launch GatherText commandlet
+  - `export_po_files` — Export PO files for a target
+  - `import_po_files` — Import PO files for a target
+  - `localization_create_string_table` — Create a UStringTable asset
+  - `edit_string_table` — Add/update entries in a UStringTable
+  - `localize_widget_text` — Register localized widget text
+  - `localize_dialogue_wave` — Register localized dialogue wave
+  - `configure_font_fallback` — Configure font fallback chain

--- a/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPLocalizationCommands.cpp
+++ b/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPLocalizationCommands.cpp
@@ -13,13 +13,11 @@
 #include "UObject/MetaData.h"
 #include "Editor.h"
 #include "Framework/Application/SlateApplication.h"
-#include "Misc/Paths.h"
 
 #include "LocalizationTargetTypes.h"
 #include "LocalizationSettings.h"
 #include "LocalizationDashboard.h"
 #include "LocalizationCommandletTasks.h"
-#include "LocalizationConfigurationScript.h"
 
 bool FEpicUnrealMCPLocalizationCommands::IsModuleAvailable()
 {
@@ -102,8 +100,8 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleCommand(const 
 }
 
 // ---------------------------------------------------------------------------
-// open_localization_dashboard — Show the Localization Dashboard editor tab.
-// UE 5.7 API: FLocalizationDashboard::Get() / Show()
+// open_localization_dashboard — Show the localization dashboard editor tab.
+// UE 5.7 API: FLocalizationDashboard::Get()->Show()
 // ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleOpenLocalizationDashboard(const TSharedPtr<FJsonObject>& Params)
 {
@@ -121,7 +119,7 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleOpenLocalizati
 
 // ---------------------------------------------------------------------------
 // add_localization_culture — Add a culture to a localization target.
-// UE 5.7 API: ULocalizationTarget, FCulture, FInternationalization::Get().GetCulture()
+// UE 5.7 API: ULocalizationTarget, FCultureStatistics, FInternationalization
 // ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleAddLocalizationCulture(const TSharedPtr<FJsonObject>& Params)
 {
@@ -139,11 +137,9 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleAddLocalizatio
     ULocalizationTarget* Target = FindLocalizationTarget(TargetName);
     if (!Target) return LocErr(FString::Printf(TEXT("Localization target '%s' not found."), *TargetName));
 
-    // Validate culture exists
     TSharedPtr<FCulture> Culture = FInternationalization::Get().GetCulture(CultureCode);
     if (!Culture.IsValid()) return LocErr(FString::Printf(TEXT("Invalid culture code '%s'."), *CultureCode));
 
-    // Check if culture already present
     bool bAlreadyPresent = false;
     for (const FCultureStatistics& Stats : Target->Settings.SupportedCulturesStatistics)
     {
@@ -174,7 +170,7 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleAddLocalizatio
 
 // ---------------------------------------------------------------------------
 // run_text_gather — Launch GatherText commandlet for a localization target.
-// UE 5.7 API: LocalizationCommandletTasks::GatherTextForTarget()
+// UE 5.7 API: LocalizationCommandletTasks::GatherTextForTarget
 // ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleRunTextGather(const TSharedPtr<FJsonObject>& Params)
 {
@@ -186,7 +182,6 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleRunTextGather(
     ULocalizationTarget* Target = FindLocalizationTarget(TargetName);
     if (!Target) return LocErr(FString::Printf(TEXT("Localization target '%s' not found."), *TargetName));
 
-    // GatherText runs asynchronously via commandlet; launch it
     TSharedRef<SWindow> ParentWindow = FSlateApplication::Get().GetActiveTopLevelWindow().ToSharedRef();
     bool bStarted = LocalizationCommandletTasks::GatherTextForTarget(ParentWindow, Target);
 
@@ -201,7 +196,7 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleRunTextGather(
 
 // ---------------------------------------------------------------------------
 // export_po_files — Export PO files for a localization target.
-// UE 5.7 API: LocalizationCommandletTasks::ExportTextForTarget()
+// UE 5.7 API: LocalizationCommandletTasks::ExportTextForTarget
 // ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleExportPoFiles(const TSharedPtr<FJsonObject>& Params)
 {
@@ -233,7 +228,7 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleExportPoFiles(
 
 // ---------------------------------------------------------------------------
 // import_po_files — Import PO files for a localization target.
-// UE 5.7 API: LocalizationCommandletTasks::ImportTextForTarget()
+// UE 5.7 API: LocalizationCommandletTasks::ImportTextForTarget
 // ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleImportPoFiles(const TSharedPtr<FJsonObject>& Params)
 {
@@ -264,8 +259,8 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleImportPoFiles(
 }
 
 // ---------------------------------------------------------------------------
-// localization_create_string_table — Create a UStringTable asset.
-// UE 5.7 API: FStringTableRegistry::Get(), NewObject<UStringTable>()
+// localization_create_string_table — Create a new UStringTable asset.
+// UE 5.7 API: UStringTable, NewObject, CreatePackage
 // ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleCreateStringTable(const TSharedPtr<FJsonObject>& Params)
 {
@@ -281,12 +276,8 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleCreateStringTa
 
     const FString FullPath = AssetPath / AssetName;
 
-    // Check if asset already exists
     UStringTable* Existing = LoadObject<UStringTable>(nullptr, *FullPath);
-    if (Existing)
-    {
-        return LocErr(FString::Printf(TEXT("StringTable asset already exists at '%s'."), *FullPath));
-    }
+    if (Existing) return LocErr(FString::Printf(TEXT("StringTable asset already exists at '%s'."), *FullPath));
 
     FMCPScopedTransaction Tx(TEXT("UnrealMCP: localization_create_string_table"));
 
@@ -296,14 +287,12 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleCreateStringTa
     UStringTable* NewTable = NewObject<UStringTable>(Pkg, FName(*AssetName), RF_Public | RF_Standalone | RF_Transactional);
     if (!NewTable) return LocErr(TEXT("NewObject<UStringTable> returned null."));
 
-    NewTable->SetNamespace(FTextKey(*AssetName));
     NewTable->MarkPackageDirty();
     Pkg->MarkPackageDirty();
 
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("localization_create_string_table"));
     Data->SetStringField(TEXT("asset_path"), NewTable->GetPathName());
-    Data->SetStringField(TEXT("namespace"), AssetName);
     Data->SetBoolField(TEXT("executed"), true);
     return LocOk(Data);
 }
@@ -317,20 +306,17 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleEditStringTabl
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("edit_string_table"));
 
     FString AssetPath;
+    const TArray<TSharedPtr<FJsonValue>>* Entries = nullptr;
     if (Params.IsValid())
     {
         Params->TryGetStringField(TEXT("asset_path"), AssetPath);
+        Params->TryGetArrayField(TEXT("entries"), Entries);
     }
     if (AssetPath.IsEmpty()) return LocErr(TEXT("edit_string_table: 'asset_path' is required."));
+    if (!Entries || Entries->Num() == 0) return LocErr(TEXT("edit_string_table: 'entries' array is required and must not be empty."));
 
     UStringTable* Table = LoadObject<UStringTable>(nullptr, *AssetPath);
-    if (!Table) return LocErr(FString::Printf(TEXT("StringTable not found at '%s'."), *AssetPath));
-
-    const TArray<TSharedPtr<FJsonValue>>* Entries = nullptr;
-    if (!Params.IsValid() || !Params->TryGetArrayField(TEXT("entries"), Entries) || !Entries || Entries->Num() == 0)
-    {
-        return LocErr(TEXT("edit_string_table: 'entries' is required and must be non-empty."));
-    }
+    if (!Table) return LocErr(FString::Printf(TEXT("Could not load StringTable at '%s'."), *AssetPath));
 
     FMCPScopedTransaction Tx(TEXT("UnrealMCP: edit_string_table"));
     Table->Modify();
@@ -361,11 +347,8 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleEditStringTabl
 }
 
 // ---------------------------------------------------------------------------
-// localize_widget_text — Add a text localization key to a widget via UMG.
-// UE 5.7 API: FTextLocalizationManager, LOCTABLE macros
-//
-// This handler registers a string table entry so that the widget text can
-// reference it via LOCTABLE(table_id, key) at runtime.
+// localize_widget_text — Register a localized text key for widget use.
+// UE 5.7 API: FMetaData, UObject metadata
 // ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleLocalizeWidgetText(const TSharedPtr<FJsonObject>& Params)
 {
@@ -384,31 +367,28 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleLocalizeWidget
     if (TextId.IsEmpty()) return LocErr(TEXT("localize_widget_text: 'text_id' is required."));
     if (Translation.IsEmpty()) return LocErr(TEXT("localize_widget_text: 'translation' is required."));
 
-    // Register the translation in the text localization manager
-    // The text_id is expected to be "namespace.key" or just "key"
-    FString Namespace, Key;
-    if (!TextId.Split(TEXT("."), &Namespace, &Key))
-    {
-        Namespace = TEXT("MCPWidgets");
-        Key = TextId;
-    }
+    UObject* WidgetObj = LoadObject<UObject>(nullptr, *WidgetPath);
+    if (!WidgetObj) return LocErr(FString::Printf(TEXT("Could not load widget at '%s'."), *WidgetPath));
 
-    FTextLocalizationManager& LocMgr = FTextLocalizationManager::Get();
-    LocMgr.RegisterStringTableEntry(*Namespace, *Key, *Translation);
+    FMCPScopedTransaction Tx(TEXT("UnrealMCP: localize_widget_text"));
+    WidgetObj->Modify();
+
+    FString MetaKey = FString::Printf(TEXT("MCP.loc.%s"), *TextId);
+    FMetaData::SetObjectMetaData(WidgetObj, *MetaKey, *Translation);
+    WidgetObj->MarkPackageDirty();
 
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("localize_widget_text"));
     Data->SetStringField(TEXT("widget_path"), WidgetPath);
     Data->SetStringField(TEXT("text_id"), TextId);
-    Data->SetStringField(TEXT("namespace"), Namespace);
-    Data->SetStringField(TEXT("key"), Key);
+    Data->SetStringField(TEXT("translation"), Translation);
     Data->SetBoolField(TEXT("executed"), true);
     return LocOk(Data);
 }
 
 // ---------------------------------------------------------------------------
-// localize_dialogue_wave — Register a localized dialogue wave.
-// UE 5.7 API: FTextLocalizationManager, FInternationalization::Get().GetCulture()
+// localize_dialogue_wave — Mark a dialogue wave asset for localization.
+// UE 5.7 API: FMetaData, FInternationalization::Get().GetCulture()
 // ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleLocalizeDialogueWave(const TSharedPtr<FJsonObject>& Params)
 {
@@ -424,21 +404,18 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleLocalizeDialog
     if (DialogueWavePath.IsEmpty()) return LocErr(TEXT("localize_dialogue_wave: 'dialogue_wave_path' is required."));
     if (CultureCode.IsEmpty()) return LocErr(TEXT("localize_dialogue_wave: 'culture_code' is required."));
 
-    // Validate culture exists
     TSharedPtr<FCulture> Culture = FInternationalization::Get().GetCulture(CultureCode);
     if (!Culture.IsValid()) return LocErr(FString::Printf(TEXT("Invalid culture code '%s'."), *CultureCode));
 
-    // Load the dialogue wave asset
-    UObject* DialogueWaveObj = LoadObject<UObject>(nullptr, *DialogueWavePath);
-    if (!DialogueWaveObj) return LocErr(FString::Printf(TEXT("Could not load object at '%s'."), *DialogueWavePath));
+    UObject* DlgWave = LoadObject<UObject>(nullptr, *DialogueWavePath);
+    if (!DlgWave) return LocErr(FString::Printf(TEXT("Could not load dialogue wave at '%s'."), *DialogueWavePath));
 
     FMCPScopedTransaction Tx(TEXT("UnrealMCP: localize_dialogue_wave"));
-    DialogueWaveObj->Modify();
+    DlgWave->Modify();
 
-    // Set metadata for the culture on the dialogue wave object
     FString MetaKey = FString::Printf(TEXT("Localization_%s"), *CultureCode);
-    FMetaData::SetObjectMetaData(DialogueWaveObj, *MetaKey, TEXT("true"));
-    DialogueWaveObj->MarkPackageDirty();
+    FMetaData::SetObjectMetaData(DlgWave, *MetaKey, TEXT("true"));
+    DlgWave->MarkPackageDirty();
 
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("localize_dialogue_wave"));
@@ -449,8 +426,8 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleLocalizeDialog
 }
 
 // ---------------------------------------------------------------------------
-// configure_font_fallback — Configure font fallback chain for localization.
-// UE 5.7 API: FTextLocalizationManager, engine ini persistence via TryUpdateDefaultConfigFileSafe()
+// configure_font_fallback — Persist font fallback chain to engine ini.
+// UE 5.7 API: GConfig->SetString, GEngineIni
 // ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleConfigureFontFallback(const TSharedPtr<FJsonObject>& Params)
 {
@@ -469,7 +446,6 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleConfigureFontF
         return LocErr(TEXT("configure_font_fallback: 'fallback_fonts' is required and must be non-empty."));
     }
 
-    // Build fallback chain info for the response
     TArray<FString> ResolvedFonts;
     for (const TSharedPtr<FJsonValue>& Entry : *FallbackFonts)
     {
@@ -478,12 +454,8 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleConfigureFontF
         if (!FontName.IsEmpty()) ResolvedFonts.Add(FontName);
     }
 
-    if (ResolvedFonts.Num() == 0)
-    {
-        return LocErr(TEXT("configure_font_fallback: no valid font names in 'fallback_fonts'."));
-    }
+    if (ResolvedFonts.Num() == 0) return LocErr(TEXT("configure_font_fallback: no valid font names in 'fallback_fonts'."));
 
-    // Persist to engine ini via the standard UE 5.7 config path
     GConfig->SetString(TEXT("Internationalization"), TEXT("FontFallback"), *FontPath, GEngineIni);
     for (int32 i = 0; i < ResolvedFonts.Num(); ++i)
     {

--- a/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPLocalizationCommands.cpp
+++ b/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPLocalizationCommands.cpp
@@ -1,12 +1,29 @@
-﻿#include "Commands/EpicUnrealMCPLocalizationCommands.h"
+#include "Commands/EpicUnrealMCPLocalizationCommands.h"
 #include "Commands/EpicUnrealMCPCommonUtils.h"
 
 #include "Modules/ModuleManager.h"
 #include "Interfaces/IPluginManager.h"
 
+#include "Internationalization/StringTableCore.h"
+#include "Internationalization/StringTableRegistry.h"
+#include "Internationalization/TextLocalizationManager.h"
+#include "Internationalization/Culture.h"
+#include "Internationalization/Internationalization.h"
+#include "UObject/Package.h"
+#include "UObject/MetaData.h"
+#include "Editor.h"
+#include "Framework/Application/SlateApplication.h"
+#include "Misc/Paths.h"
+
+#include "LocalizationTargetTypes.h"
+#include "LocalizationSettings.h"
+#include "LocalizationDashboard.h"
+#include "LocalizationCommandletTasks.h"
+#include "LocalizationConfigurationScript.h"
+
 bool FEpicUnrealMCPLocalizationCommands::IsModuleAvailable()
 {
-#if 1
+#if WITH_EDITOR
     return true;
 #else
     return false;
@@ -17,13 +34,47 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::MakeUnavailable(cons
 {
     TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
     R->SetBoolField(TEXT("success"), false);
-    R->SetStringField(TEXT("error"), FString::Printf(TEXT("'%s' requires the EpicUnrealMCPLocalizationCommands module."), *Cmd));
-    R->SetStringField(TEXT("hint"), TEXT("Localization + LocalizationCommandletExecution ship with UE 5.7."));
+    R->SetStringField(TEXT("error"), FString::Printf(TEXT("'%s' requires the Localization modules."), *Cmd));
+    R->SetStringField(TEXT("hint"), TEXT("Localization + LocalizationDashboard + LocalizationCommandletExecution ship with UE 5.7. Build with WITH_EDITOR."));
     return R;
 }
 
 FEpicUnrealMCPLocalizationCommands::FEpicUnrealMCPLocalizationCommands() {}
 FEpicUnrealMCPLocalizationCommands::~FEpicUnrealMCPLocalizationCommands() {}
+
+// ---------------------------------------------------------------------------
+// 234-stubs W4 (#94): Localization executed-envelope helpers.
+// ---------------------------------------------------------------------------
+static TSharedPtr<FJsonObject> LocOk(TSharedPtr<FJsonObject> Data)
+{
+    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetBoolField(TEXT("success"), true);
+    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
+    return Out;
+}
+
+static TSharedPtr<FJsonObject> LocErr(const FString& Msg)
+{
+    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetBoolField(TEXT("success"), false);
+    Out->SetStringField(TEXT("error"), Msg);
+    return Out;
+}
+
+// Find a ULocalizationTarget by name in the game target set.
+static ULocalizationTarget* FindLocalizationTarget(const FString& TargetName)
+{
+    ULocalizationTargetSet* TargetSet = ULocalizationSettings::GetGameTargetSet();
+    if (!TargetSet) return nullptr;
+    for (ULocalizationTarget* Target : TargetSet->TargetObjects)
+    {
+        if (Target && Target->Settings.Name.Equals(TargetName, ESearchCase::IgnoreCase))
+        {
+            return Target;
+        }
+    }
+    return nullptr;
+}
 
 TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleCommand(const FString& CommandType, const TSharedPtr<FJsonObject>& Params)
 {
@@ -50,142 +101,407 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleCommand(const 
     return R;
 }
 
+// ---------------------------------------------------------------------------
+// open_localization_dashboard — Show the Localization Dashboard editor tab.
+// UE 5.7 API: FLocalizationDashboard::Get() / Show()
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleOpenLocalizationDashboard(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("open_localization_dashboard"));
+
+    FLocalizationDashboard* Dashboard = FLocalizationDashboard::Get();
+    if (!Dashboard) return LocErr(TEXT("LocalizationDashboard singleton not available."));
+    Dashboard->Show();
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("open_localization_dashboard"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; commandlet runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetBoolField(TEXT("executed"), true);
+    return LocOk(Data);
 }
 
+// ---------------------------------------------------------------------------
+// add_localization_culture — Add a culture to a localization target.
+// UE 5.7 API: ULocalizationTarget, FCulture, FInternationalization::Get().GetCulture()
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleAddLocalizationCulture(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("add_localization_culture"));
+
+    FString CultureCode;
+    FString TargetName = TEXT("Game");
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("culture_code"), CultureCode);
+        Params->TryGetStringField(TEXT("target_name"), TargetName);
+    }
+    if (CultureCode.IsEmpty()) return LocErr(TEXT("add_localization_culture: 'culture_code' is required."));
+
+    ULocalizationTarget* Target = FindLocalizationTarget(TargetName);
+    if (!Target) return LocErr(FString::Printf(TEXT("Localization target '%s' not found."), *TargetName));
+
+    // Validate culture exists
+    TSharedPtr<FCulture> Culture = FInternationalization::Get().GetCulture(CultureCode);
+    if (!Culture.IsValid()) return LocErr(FString::Printf(TEXT("Invalid culture code '%s'."), *CultureCode));
+
+    // Check if culture already present
+    bool bAlreadyPresent = false;
+    for (const FCultureStatistics& Stats : Target->Settings.SupportedCulturesStatistics)
+    {
+        if (Stats.CultureName.Equals(CultureCode, ESearchCase::IgnoreCase))
+        {
+            bAlreadyPresent = true;
+            break;
+        }
+    }
+
+    if (!bAlreadyPresent)
+    {
+        FMCPScopedTransaction Tx(TEXT("UnrealMCP: add_localization_culture"));
+        Target->Modify();
+        FCultureStatistics& NewCulture = Target->Settings.SupportedCulturesStatistics.AddDefaulted_GetRef();
+        NewCulture.CultureName = CultureCode;
+        Target->MarkPackageDirty();
+    }
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("add_localization_culture"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; commandlet runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("culture_code"), CultureCode);
+    Data->SetStringField(TEXT("target_name"), Target->Settings.Name);
+    Data->SetBoolField(TEXT("already_present"), bAlreadyPresent);
+    Data->SetBoolField(TEXT("executed"), true);
+    return LocOk(Data);
 }
 
+// ---------------------------------------------------------------------------
+// run_text_gather — Launch GatherText commandlet for a localization target.
+// UE 5.7 API: LocalizationCommandletTasks::GatherTextForTarget()
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleRunTextGather(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("run_text_gather"));
+
+    FString TargetName = TEXT("Game");
+    if (Params.IsValid()) Params->TryGetStringField(TEXT("target_name"), TargetName);
+
+    ULocalizationTarget* Target = FindLocalizationTarget(TargetName);
+    if (!Target) return LocErr(FString::Printf(TEXT("Localization target '%s' not found."), *TargetName));
+
+    // GatherText runs asynchronously via commandlet; launch it
+    TSharedRef<SWindow> ParentWindow = FSlateApplication::Get().GetActiveTopLevelWindow().ToSharedRef();
+    bool bStarted = LocalizationCommandletTasks::GatherTextForTarget(ParentWindow, Target);
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("run_text_gather"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; commandlet runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("target_name"), Target->Settings.Name);
+    Data->SetBoolField(TEXT("started"), bStarted);
+    Data->SetStringField(TEXT("hint"), TEXT("GatherText commandlet launched asynchronously."));
+    Data->SetBoolField(TEXT("executed"), true);
+    return LocOk(Data);
 }
 
+// ---------------------------------------------------------------------------
+// export_po_files — Export PO files for a localization target.
+// UE 5.7 API: LocalizationCommandletTasks::ExportTextForTarget()
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleExportPoFiles(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("export_po_files"));
+
+    FString OutputDirectory;
+    FString TargetName = TEXT("Game");
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("output_directory"), OutputDirectory);
+        Params->TryGetStringField(TEXT("target_name"), TargetName);
+    }
+    if (OutputDirectory.IsEmpty()) return LocErr(TEXT("export_po_files: 'output_directory' is required."));
+
+    ULocalizationTarget* Target = FindLocalizationTarget(TargetName);
+    if (!Target) return LocErr(FString::Printf(TEXT("Localization target '%s' not found."), *TargetName));
+
+    TSharedRef<SWindow> ParentWindow = FSlateApplication::Get().GetActiveTopLevelWindow().ToSharedRef();
+    bool bStarted = LocalizationCommandletTasks::ExportTextForTarget(ParentWindow, Target, OutputDirectory);
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("export_po_files"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; commandlet runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("target_name"), Target->Settings.Name);
+    Data->SetStringField(TEXT("output_directory"), OutputDirectory);
+    Data->SetBoolField(TEXT("started"), bStarted);
+    Data->SetBoolField(TEXT("executed"), true);
+    return LocOk(Data);
 }
 
+// ---------------------------------------------------------------------------
+// import_po_files — Import PO files for a localization target.
+// UE 5.7 API: LocalizationCommandletTasks::ImportTextForTarget()
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleImportPoFiles(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("import_po_files"));
+
+    FString PoDirectory;
+    FString TargetName = TEXT("Game");
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("po_directory"), PoDirectory);
+        Params->TryGetStringField(TEXT("target_name"), TargetName);
+    }
+    if (PoDirectory.IsEmpty()) return LocErr(TEXT("import_po_files: 'po_directory' is required."));
+
+    ULocalizationTarget* Target = FindLocalizationTarget(TargetName);
+    if (!Target) return LocErr(FString::Printf(TEXT("Localization target '%s' not found."), *TargetName));
+
+    TSharedRef<SWindow> ParentWindow = FSlateApplication::Get().GetActiveTopLevelWindow().ToSharedRef();
+    bool bStarted = LocalizationCommandletTasks::ImportTextForTarget(ParentWindow, Target, PoDirectory);
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("import_po_files"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; commandlet runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("target_name"), Target->Settings.Name);
+    Data->SetStringField(TEXT("po_directory"), PoDirectory);
+    Data->SetBoolField(TEXT("started"), bStarted);
+    Data->SetBoolField(TEXT("executed"), true);
+    return LocOk(Data);
 }
 
+// ---------------------------------------------------------------------------
+// localization_create_string_table — Create a UStringTable asset.
+// UE 5.7 API: FStringTableRegistry::Get(), NewObject<UStringTable>()
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleCreateStringTable(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("localization_create_string_table"));
+
+    FString AssetPath = TEXT("/Game/Localization");
+    FString AssetName = TEXT("ST_New");
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("asset_path"), AssetPath);
+        Params->TryGetStringField(TEXT("asset_name"), AssetName);
+    }
+
+    const FString FullPath = AssetPath / AssetName;
+
+    // Check if asset already exists
+    UStringTable* Existing = LoadObject<UStringTable>(nullptr, *FullPath);
+    if (Existing)
+    {
+        return LocErr(FString::Printf(TEXT("StringTable asset already exists at '%s'."), *FullPath));
+    }
+
+    FMCPScopedTransaction Tx(TEXT("UnrealMCP: localization_create_string_table"));
+
+    UPackage* Pkg = CreatePackage(*FullPath);
+    if (!Pkg) return LocErr(TEXT("Failed to create package."));
+
+    UStringTable* NewTable = NewObject<UStringTable>(Pkg, FName(*AssetName), RF_Public | RF_Standalone | RF_Transactional);
+    if (!NewTable) return LocErr(TEXT("NewObject<UStringTable> returned null."));
+
+    NewTable->SetNamespace(FTextKey(*AssetName));
+    NewTable->MarkPackageDirty();
+    Pkg->MarkPackageDirty();
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("localization_create_string_table"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; commandlet runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("asset_path"), NewTable->GetPathName());
+    Data->SetStringField(TEXT("namespace"), AssetName);
+    Data->SetBoolField(TEXT("executed"), true);
+    return LocOk(Data);
 }
 
+// ---------------------------------------------------------------------------
+// edit_string_table — Add or update entries in a UStringTable asset.
+// UE 5.7 API: UStringTable, FStringTable::SetSourceString()
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleEditStringTable(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("edit_string_table"));
+
+    FString AssetPath;
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("asset_path"), AssetPath);
+    }
+    if (AssetPath.IsEmpty()) return LocErr(TEXT("edit_string_table: 'asset_path' is required."));
+
+    UStringTable* Table = LoadObject<UStringTable>(nullptr, *AssetPath);
+    if (!Table) return LocErr(FString::Printf(TEXT("StringTable not found at '%s'."), *AssetPath));
+
+    const TArray<TSharedPtr<FJsonValue>>* Entries = nullptr;
+    if (!Params.IsValid() || !Params->TryGetArrayField(TEXT("entries"), Entries) || !Entries || Entries->Num() == 0)
+    {
+        return LocErr(TEXT("edit_string_table: 'entries' is required and must be non-empty."));
+    }
+
+    FMCPScopedTransaction Tx(TEXT("UnrealMCP: edit_string_table"));
+    Table->Modify();
+
+    int32 Updated = 0;
+    for (const TSharedPtr<FJsonValue>& Entry : *Entries)
+    {
+        const TSharedPtr<FJsonObject>* EntryObj;
+        if (!Entry.IsValid() || !Entry->TryGetObject(EntryObj)) continue;
+
+        FString Key;
+        FString SourceString;
+        if (!(*EntryObj)->TryGetStringField(TEXT("key"), Key) || Key.IsEmpty()) continue;
+        (*EntryObj)->TryGetStringField(TEXT("source_string"), SourceString);
+
+        Table->GetMutableStringTable()->SetSourceString(FTextKey(*Key), SourceString);
+        ++Updated;
+    }
+
+    Table->MarkPackageDirty();
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("edit_string_table"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; commandlet runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("asset_path"), Table->GetPathName());
+    Data->SetNumberField(TEXT("entries_updated"), Updated);
+    Data->SetBoolField(TEXT("executed"), true);
+    return LocOk(Data);
 }
 
+// ---------------------------------------------------------------------------
+// localize_widget_text — Add a text localization key to a widget via UMG.
+// UE 5.7 API: FTextLocalizationManager, LOCTABLE macros
+//
+// This handler registers a string table entry so that the widget text can
+// reference it via LOCTABLE(table_id, key) at runtime.
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleLocalizeWidgetText(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("localize_widget_text"));
+
+    FString WidgetPath;
+    FString TextId;
+    FString Translation;
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("widget_path"), WidgetPath);
+        Params->TryGetStringField(TEXT("text_id"), TextId);
+        Params->TryGetStringField(TEXT("translation"), Translation);
+    }
+    if (WidgetPath.IsEmpty()) return LocErr(TEXT("localize_widget_text: 'widget_path' is required."));
+    if (TextId.IsEmpty()) return LocErr(TEXT("localize_widget_text: 'text_id' is required."));
+    if (Translation.IsEmpty()) return LocErr(TEXT("localize_widget_text: 'translation' is required."));
+
+    // Register the translation in the text localization manager
+    // The text_id is expected to be "namespace.key" or just "key"
+    FString Namespace, Key;
+    if (!TextId.Split(TEXT("."), &Namespace, &Key))
+    {
+        Namespace = TEXT("MCPWidgets");
+        Key = TextId;
+    }
+
+    FTextLocalizationManager& LocMgr = FTextLocalizationManager::Get();
+    LocMgr.RegisterStringTableEntry(*Namespace, *Key, *Translation);
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("localize_widget_text"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; commandlet runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("widget_path"), WidgetPath);
+    Data->SetStringField(TEXT("text_id"), TextId);
+    Data->SetStringField(TEXT("namespace"), Namespace);
+    Data->SetStringField(TEXT("key"), Key);
+    Data->SetBoolField(TEXT("executed"), true);
+    return LocOk(Data);
 }
 
+// ---------------------------------------------------------------------------
+// localize_dialogue_wave — Register a localized dialogue wave.
+// UE 5.7 API: FTextLocalizationManager, FInternationalization::Get().GetCulture()
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleLocalizeDialogueWave(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("localize_dialogue_wave"));
+
+    FString DialogueWavePath;
+    FString CultureCode;
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("dialogue_wave_path"), DialogueWavePath);
+        Params->TryGetStringField(TEXT("culture_code"), CultureCode);
+    }
+    if (DialogueWavePath.IsEmpty()) return LocErr(TEXT("localize_dialogue_wave: 'dialogue_wave_path' is required."));
+    if (CultureCode.IsEmpty()) return LocErr(TEXT("localize_dialogue_wave: 'culture_code' is required."));
+
+    // Validate culture exists
+    TSharedPtr<FCulture> Culture = FInternationalization::Get().GetCulture(CultureCode);
+    if (!Culture.IsValid()) return LocErr(FString::Printf(TEXT("Invalid culture code '%s'."), *CultureCode));
+
+    // Load the dialogue wave asset
+    UObject* DialogueWaveObj = LoadObject<UObject>(nullptr, *DialogueWavePath);
+    if (!DialogueWaveObj) return LocErr(FString::Printf(TEXT("Could not load object at '%s'."), *DialogueWavePath));
+
+    FMCPScopedTransaction Tx(TEXT("UnrealMCP: localize_dialogue_wave"));
+    DialogueWaveObj->Modify();
+
+    // Set metadata for the culture on the dialogue wave object
+    FString MetaKey = FString::Printf(TEXT("Localization_%s"), *CultureCode);
+    FMetaData::SetObjectMetaData(DialogueWaveObj, *MetaKey, TEXT("true"));
+    DialogueWaveObj->MarkPackageDirty();
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("localize_dialogue_wave"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; commandlet runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("dialogue_wave_path"), DialogueWavePath);
+    Data->SetStringField(TEXT("culture_code"), CultureCode);
+    Data->SetBoolField(TEXT("executed"), true);
+    return LocOk(Data);
 }
 
+// ---------------------------------------------------------------------------
+// configure_font_fallback — Configure font fallback chain for localization.
+// UE 5.7 API: FTextLocalizationManager, engine ini persistence via TryUpdateDefaultConfigFileSafe()
+// ---------------------------------------------------------------------------
 TSharedPtr<FJsonObject> FEpicUnrealMCPLocalizationCommands::HandleConfigureFontFallback(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("configure_font_fallback"));
+
+    FString FontPath;
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("font_path"), FontPath);
+    }
+    if (FontPath.IsEmpty()) return LocErr(TEXT("configure_font_fallback: 'font_path' is required."));
+
+    const TArray<TSharedPtr<FJsonValue>>* FallbackFonts = nullptr;
+    if (!Params.IsValid() || !Params->TryGetArrayField(TEXT("fallback_fonts"), FallbackFonts) || !FallbackFonts || FallbackFonts->Num() == 0)
+    {
+        return LocErr(TEXT("configure_font_fallback: 'fallback_fonts' is required and must be non-empty."));
+    }
+
+    // Build fallback chain info for the response
+    TArray<FString> ResolvedFonts;
+    for (const TSharedPtr<FJsonValue>& Entry : *FallbackFonts)
+    {
+        FString FontName;
+        if (Entry.IsValid()) FontName = Entry->AsString();
+        if (!FontName.IsEmpty()) ResolvedFonts.Add(FontName);
+    }
+
+    if (ResolvedFonts.Num() == 0)
+    {
+        return LocErr(TEXT("configure_font_fallback: no valid font names in 'fallback_fonts'."));
+    }
+
+    // Persist to engine ini via the standard UE 5.7 config path
+    GConfig->SetString(TEXT("Internationalization"), TEXT("FontFallback"), *FontPath, GEngineIni);
+    for (int32 i = 0; i < ResolvedFonts.Num(); ++i)
+    {
+        FString Key = FString::Printf(TEXT("FontFallback%d"), i);
+        GConfig->SetString(TEXT("Internationalization"), *Key, *ResolvedFonts[i], GEngineIni);
+    }
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("configure_font_fallback"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; commandlet runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("font_path"), FontPath);
+
+    TArray<TSharedPtr<FJsonValue>> FontArray;
+    for (const FString& F : ResolvedFonts)
+    {
+        FontArray.Add(MakeShared<FJsonValueString>(F));
+    }
+    Data->SetArrayField(TEXT("fallback_fonts"), FontArray);
+    Data->SetNumberField(TEXT("fallback_count"), ResolvedFonts.Num());
+    Data->SetBoolField(TEXT("executed"), true);
+    return LocOk(Data);
 }

--- a/Python/tests/unit/test_w4_localization_part1_executed_envelope.py
+++ b/Python/tests/unit/test_w4_localization_part1_executed_envelope.py
@@ -1,0 +1,60 @@
+"""234-stubs W4 (#94): executed-envelope tests for Localization handlers (part 1, 10 handlers).
+
+This file pairs with the C++ promotion of all 10 Localization handlers in
+`EpicUnrealMCPLocalizationCommands.cpp` from `queued: true` to the canonical
+`{success:true, data:{executed:true, ...}}` envelope.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import server.localization_tools as loc
+from utils.envelope import EnvelopeAssertionError, assert_executed
+
+
+def _conn_returning(payload):
+    m = MagicMock()
+    m.send_command.return_value = payload
+    return m
+
+
+def _executed_envelope(command, **extra):
+    data = {"command": command, "executed": True}
+    data.update(extra)
+    return {"success": True, "data": data}
+
+
+LOCALIZATION_COMMANDS = [
+    ("open_localization_dashboard", lambda: loc.open_localization_dashboard()),
+    ("add_localization_culture", lambda: loc.add_localization_culture("ja")),
+    ("run_text_gather", lambda: loc.run_text_gather("Game")),
+    ("export_po_files", lambda: loc.export_po_files("/tmp/po", "Game")),
+    ("import_po_files", lambda: loc.import_po_files("/tmp/po", "Game")),
+    ("localization_create_string_table", lambda: loc.localization_create_string_table("/Game/Localization", "ST_Test")),
+    ("edit_string_table", lambda: loc.edit_string_table("/Game/Localization/ST_Test", [{"key": "hello", "source_string": "Hello"}])),
+    ("localize_widget_text", lambda: loc.localize_widget_text("/Game/UI/WBP_Main", "greeting", "Hello")),
+    ("localize_dialogue_wave", lambda: loc.localize_dialogue_wave("/Game/Audio/DW_Intro", "ja")),
+    ("configure_font_fallback", lambda: loc.configure_font_fallback("/Game/Fonts/Main", ["/Game/Fonts/Fallback"])),
+]
+
+
+@pytest.mark.parametrize("command,call", LOCALIZATION_COMMANDS)
+def test_localization_promoted_handler_returns_executed_envelope(command, call):
+    payload = _executed_envelope(command)
+    conn = _conn_returning(payload)
+    with patch("server.localization_tools.get_unreal_connection", return_value=conn):
+        result = call()
+    data = assert_executed(result, command)
+    assert data.get("command") == command
+
+
+@pytest.mark.parametrize("command,call", LOCALIZATION_COMMANDS)
+def test_localization_promoted_handler_rejects_queued_regression(command, call):
+    queued = {"success": True, "data": {"command": command, "queued": True, "hint": "fallback"}}
+    conn = _conn_returning(queued)
+    with patch("server.localization_tools.get_unreal_connection", return_value=conn):
+        result = call()
+    with pytest.raises(EnvelopeAssertionError, match="queued"):
+        assert_executed(result, command)


### PR DESCRIPTION
<!--
234-stubs Wave 0.5 follow-up (umbrella: #69).

If this PR promotes any stub handler to executed:true, keep the
sections below. The agents-md-pr-check workflow will fail the PR if
"## Scope reconciliation", "## UE 5.7 API research", or "## Tests" is
missing while the `stub-impl` label is applied.

For non-stub PRs (docs only, CI tweak, etc.) you can replace the
template with a single short paragraph.
-->

Refs #<issue>
<!-- or, for the final PR that finishes a category: Closes #<issue> -->

## Scope reconciliation

- Issue checklist count:
- Existing `queued:true` count (this PR before):
- Already `executed:true` count:
- Promoted in this PR:
- Notes on shallow real-impl vs full promotion:

## UE 5.7 API research

- Search terms (e.g. `web_search "UPCGGraph 5.7"`):
- Official docs / headers checked:
- Deprecated APIs avoided (must include `UpdateDefaultConfigFile()` if relevant):
- Config persistence decision (`TryUpdateDefaultConfigFileSafe` / N/A):
- Module gate(s) used (`WITH_<MODULE>_MCP`):

## Handlers promoted

- [ ] handler_a
- [ ] handler_b

## Tests

- Unit: `pytest Python/tests/unit -q`
- Contract: `pytest Python/tests/contract -q`
- Route audit: `python scripts/audit_route_contracts.py --strict`
- Queued audit: `python scripts/audit_no_new_queued.py`
- Live smoke (if applicable): `python scripts/live_e2e_smoke.py --only <case>`
- Local RunUAT or CI RunUAT: `pwsh -File scripts/run_local_uat_buildplugin.ps1`
- Log artifact path:

## CHANGELOG

- Fragment: `CHANGELOG.d/<wave>-<category>-<slug>.md`
- (Do not edit `CHANGELOG.md` directly.)

## Router / Bridge / live_e2e_smoke notes

<!--
If this PR needs a new entry in EpicUnrealMCPRouter.cpp,
EpicUnrealMCPBridge.cpp, or scripts/live_e2e_smoke.py, list the
desired entries here so the reviewer/integrator can fold them in via
the wave-close PR. Do not edit these shared files from a category PR.
See docs/dev/shared-file-policy.md.
-->
