### PR TITLE
feat(234-stubs W5 #101): promote 2 Testing/Validation handlers to executed envelope

### DIFF
--- a/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPTestingValidationCommands.cpp
+++ b/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPTestingValidationCommands.cpp
@@ -418,15 +418,35 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPTestingValidationCommands::HandleRunGamepl
 TSharedPtr<FJsonObject> FEpicUnrealMCPTestingValidationCommands::HandleRunPythonUnitTest(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("run_python_unit_test"));
+
+    FString TestPath = TEXT("Python/tests/unit");
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("test_path"), TestPath);
+    }
+
+    FString PythonExe = FPaths::ConvertRelativePathToFull(
+        FPaths::ProjectDir() / TEXT("Python") / TEXT("venv") / TEXT("Scripts") / TEXT("python.exe"));
+    if (!FPaths::FileExists(PythonExe))
+        PythonExe = TEXT("python");
+
+    FString Args = FString::Printf(TEXT("-m pytest %s --tb=short -q"), *TestPath);
+    int32 ReturnCode = -1;
+    FString StdOut;
+    FString StdErr;
+    FPlatformProcess::ExecProcess(*PythonExe, *Args, &ReturnCode, &StdOut, &StdErr);
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("run_python_unit_test"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; FAutomationTestFramework runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    Data->SetStringField(TEXT("test_path"), TestPath);
+    Data->SetNumberField(TEXT("exit_code"), ReturnCode);
+    Data->SetBoolField(TEXT("passed"), ReturnCode == 0);
+    if (!StdOut.IsEmpty())
+        Data->SetStringField(TEXT("stdout"), StdOut.Left(2048));
+    if (!StdErr.IsEmpty())
+        Data->SetStringField(TEXT("stderr"), StdErr.Left(1024));
+    Data->SetBoolField(TEXT("executed"), true);
+    return TvOk(Data);
 }
 
 // ---------------------------------------------------------------------------
@@ -435,13 +455,35 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPTestingValidationCommands::HandleRunPython
 TSharedPtr<FJsonObject> FEpicUnrealMCPTestingValidationCommands::HandleRunRustTest(const TSharedPtr<FJsonObject>& Params)
 {
     if (!IsModuleAvailable()) return MakeUnavailable(TEXT("run_rust_test"));
+
+    FString TestFilter;
+    if (Params.IsValid())
+    {
+        Params->TryGetStringField(TEXT("test_filter"), TestFilter);
+    }
+
+    FString CargoExe = TEXT("cargo");
+    int32 ReturnCode = -1;
+    FString StdOut;
+    FString StdErr;
+
+    FString Args = TEXT("test");
+    if (!TestFilter.IsEmpty())
+        Args += FString::Printf(TEXT(" %s"), *TestFilter);
+    Args += TEXT(" -- --nocapture");
+
+    FPlatformProcess::ExecProcess(*CargoExe, *Args, &ReturnCode, &StdOut, &StdErr);
+
     TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("command"), TEXT("run_rust_test"));
-    if (Params.IsValid()) Data->SetObjectField(TEXT("params"), Params.ToSharedRef());
-    Data->SetBoolField(TEXT("queued"), true);
-    Data->SetStringField(TEXT("hint"), TEXT("Payload accepted; FAutomationTestFramework runs asynchronously."));
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("success"), true);
-    Out->SetObjectField(TEXT("data"), Data.ToSharedRef());
-    return Out;
+    if (!TestFilter.IsEmpty())
+        Data->SetStringField(TEXT("test_filter"), TestFilter);
+    Data->SetNumberField(TEXT("exit_code"), ReturnCode);
+    Data->SetBoolField(TEXT("passed"), ReturnCode == 0);
+    if (!StdOut.IsEmpty())
+        Data->SetStringField(TEXT("stdout"), StdOut.Left(2048));
+    if (!StdErr.IsEmpty())
+        Data->SetStringField(TEXT("stderr"), StdErr.Left(1024));
+    Data->SetBoolField(TEXT("executed"), true);
+    return TvOk(Data);
 }

--- a/Python/tests/unit/test_w5_testing_validation_part2_executed_envelope.py
+++ b/Python/tests/unit/test_w5_testing_validation_part2_executed_envelope.py
@@ -1,0 +1,44 @@
+"""W5 executed-envelope tests for Testing/Validation part 2 handlers (issue #101)."""
+from unittest.mock import patch, MagicMock
+import pytest
+import server.testing_validation_tools as m
+from utils.envelope import assert_executed, assert_no_queued, EnvelopeAssertionError
+
+
+def _conn_returning(payload):
+    c = MagicMock()
+    c.send_command.return_value = payload
+    return c
+
+
+def _executed_envelope(command, extra=None):
+    data = {"executed": True, "command": command}
+    if extra:
+        data.update(extra)
+    return {"success": True, "data": data}
+
+
+TESTING_PART2_COMMANDS = [
+    ("run_python_unit_test", lambda: m.run_python_unit_test("Python/tests/unit")),
+    ("run_rust_test", lambda: m.run_rust_test("")),
+]
+
+
+@pytest.mark.parametrize("command,call", TESTING_PART2_COMMANDS)
+def test_testing_part2_promoted_handler_returns_executed_envelope(command, call):
+    payload = _executed_envelope(command)
+    conn = _conn_returning(payload)
+    with patch("server.testing_validation_tools.get_unreal_connection", return_value=conn):
+        result = call()
+    data = assert_executed(result, command)
+    assert data.get("command") == command
+
+
+@pytest.mark.parametrize("command,call", TESTING_PART2_COMMANDS)
+def test_testing_part2_promoted_handler_rejects_queued_regression(command, call):
+    queued = {"success": True, "data": {"command": command, "queued": True, "hint": "fallback"}}
+    conn = _conn_returning(queued)
+    with patch("server.testing_validation_tools.get_unreal_connection", return_value=conn):
+        result = call()
+    with pytest.raises(EnvelopeAssertionError, match="queued"):
+        assert_executed(result, command)


### PR DESCRIPTION
Refs #101

## Scope reconciliation

- Issue checklist count: 10
- Existing `queued:true` count (this PR before): 2 (run_python_unit_test, run_rust_test)
- Already `executed:true` count: 8 (from W5-4 / PR #143)
- Promoted in this PR: 2
- Notes: Part 2 of Testing/Validation category. Part 1 promoted 8 handlers in PR #143. Final W5 PR — all 31 W5 stubs promoted after this.

## UE 5.7 API research

- Search terms: `FPlatformProcess::ExecProcess 5.7`, `FAutomationTestFramework 5.7`
- Official docs / headers checked: `HAL/PlatformProcess.h`, `Misc/Paths.h`
- Deprecated APIs avoided: N/A (FPlatformProcess::ExecProcess is stable)
- Config persistence decision: N/A (no config changes, external process execution only)
- Module gate(s) used: `WITH_EDITOR`

## Handlers promoted

- [x] run_python_unit_test
- [x] run_rust_test

## Tests

- Unit: `pytest Python/tests/unit/test_w5_testing_validation_part2_executed_envelope.py Python/tests/unit/test_testing_validation_tools.py -v` (30 passed)
- Queued audit: no `queued:true` in promoted handlers

## CHANGELOG

- Fragment: `CHANGELOG.d/w5-testingval-p2-promote.md`

## Router / Bridge / live_e2e_smoke notes

- No new router/bridge entries needed (commands already registered in W0.5 scaffold)

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)